### PR TITLE
Senyo888 patch 1 v2.0.1 fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@
 - [Configuration Screenshots (Visual Guide)](#configuration-screenshots-visual-guide)
 - [Post-Configuration Workflow](#post-configuration-workflow)
 - [How to Use Services](#how-to-use-services)
+- [Release Notes ](#release-notes)
 - [Design Philosophy](#design-philosophy)
 
 ---
@@ -586,6 +587,32 @@ Safety guidance:
 - run `dump_diagnostics` before purge if you want a snapshot for troubleshooting
 
 ---
+
+## Release Notes 
+
+### v2.0.1 fixes
+
+- fixed Fahrenheit telemetry normalization by converting all internal temperature math to Celsius before averages, spreads, deltas, and thresholds
+- fixed aggregate behavior so IAQ/AQ averages ignore `unknown`, `unavailable`, and non-numeric states and only return unknown when no valid values exist
+- added aggregate exclusion debug logging with explicit reasons (`unknown`, `unavailable`, `non_numeric`, `unit_mismatch`)
+- added zone mapping duplicate warnings in setup/options and new duplicate diagnostics sensor state
+- added `alert_only_mode` (monitor + alerts only) to suppress automation control lanes for users without output hardware
+- improved UI placeholder pruning so optional outputs/controls are hidden when not configured, including alert-only control suppression
+- fixed alert-only card rendering edge case by pruning invalid leftover `conditional` blocks after entity pruning
+- updated Current Air Control reason field behavior for alert-only mode so it reports monitoring/alerts context and does not imply missing output controls
+- options changes that flip `alert_only_mode` now trigger UI card refresh/export regeneration and a notification
+- expanded options flow editing so users can revisit skipped lanes and add/edit alerts later
+- expanded post-configuration lane management so humidifier and AQ lanes can be re-added after removal, and telemetry changes log explicit add/update/remove actions
+- alert target lights are now fully optional end-to-end (config/options/service/runtime); alerts still trigger without flash entities
+- hardened service input validation (safe filename/url path/layout checks), bounded flash parameters, and diagnostics attribute redaction for sensitive keys
+
+### Migration notes
+
+- `alert_only_mode` is now available in Global Gates (setup and options). Disable it later to restore normal control entities/lane behavior.
+- new computed sensor: `HI Zone Mapping Duplicates` (`hi_<entry_id>_zone_mapping_duplicates`) exposes duplicate zone mapping status and details.
+- generated V2 cards now prune unresolved optional control/output entities instead of leaving stale references.
+- if your dashboard uses Manual cards, re-copy/paste the latest exported YAML after changing `alert_only_mode` so the UI and reason panel match the selected mode.
+
 
 ## Design Philosophy
 

--- a/__init__.py
+++ b/__init__.py
@@ -160,4 +160,39 @@ def _effective_entry_config(entry: ConfigEntry) -> dict:
 
 async def _async_options_updated(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Reload entry when options change so runtime lanes immediately honor updates."""
+    previous_cfg = (
+        hass.data.get(DOMAIN, {}).get(entry.entry_id, {}).get("config", {}) or {}
+    )
+    prev_alert_only = bool(previous_cfg.get("alert_only_mode", _entry_alert_only_mode(entry)))
+    next_alert_only = _entry_alert_only_mode(entry)
     await hass.config_entries.async_reload(entry.entry_id)
+    if prev_alert_only == next_alert_only:
+        return
+
+    _LOGGER.info(
+        "HI entry %s alert-only mode changed to %s; regenerating UI card exports.",
+        entry.entry_id,
+        next_alert_only,
+    )
+    await _async_refresh_and_dump_cards(hass, entry.entry_id)
+    await hass.services.async_call(
+        "persistent_notification",
+        "create",
+        {
+            "title": "Humidity Intelligence UI Updated",
+            "message": (
+                "Alert-only mode changed. Updated card files were written to "
+                "/config/humidity_intelligence_cards_<layout>.yaml. "
+                "Re-copy/paste the layout YAML into your Manual card to apply control visibility changes."
+            ),
+        },
+        blocking=False,
+    )
+
+
+def _entry_alert_only_mode(entry: ConfigEntry) -> bool:
+    options = getattr(entry, "options", None) or {}
+    if "alert_only_mode" in options:
+        return bool(options.get("alert_only_mode"))
+    data = getattr(entry, "data", None) or {}
+    return bool(data.get("alert_only_mode", False))

--- a/automations/engine.py
+++ b/automations/engine.py
@@ -14,6 +14,7 @@ from homeassistant.helpers.event import async_track_state_change_event, async_tr
 from ..const import (
     ALERT_THRESHOLD_BOUNDS,
     ALERT_TRIGGER_DEFS,
+    ROOM_SCOPED_ALERT_TRIGGERS,
     DOMAIN,
     ENGINE_INTERVAL_MAX,
     ENGINE_INTERVAL_MIN,
@@ -28,6 +29,7 @@ from ..const import (
     ZONE_OUTPUT_LEVEL_MIN,
 )
 from ..services import SERVICE_FLASH_LIGHTS
+from ..helpers.parsing import hass_temperature_unit, parse_numeric, parse_temperature
 
 CO_EMERGENCY_START = 15
 CO_EMERGENCY_CLEAR = 10
@@ -46,6 +48,7 @@ class HIAutomationEngine:
         self.humidifiers = self._cfg("humidifiers", {})
         self.aq = self._cfg("aq", {})
         self.alerts = self._cfg("alerts", [])
+        self.alert_only_mode = bool(self._cfg("alert_only_mode", False))
         self._unsub = None
         self._periodic = None
         self._aq_tasks: Dict[str, asyncio.Task] = {}
@@ -68,6 +71,14 @@ class HIAutomationEngine:
             ENGINE_INTERVAL_MAX,
             ENGINE_INTERVAL_MINUTES_DEFAULT,
         )
+        if self.alert_only_mode:
+            self.zones = {}
+            self.humidifiers = {}
+            self.aq = {}
+            _LOGGER.info(
+                "HI entry %s is running in alert-only mode; zone/humidifier/AQ output lanes are disabled.",
+                entry.entry_id,
+            )
 
     def _cfg(self, key: str, default: Any) -> Any:
         if self.entry.options and key in self.entry.options:
@@ -364,13 +375,20 @@ class HIAutomationEngine:
             if last and datetime.now() - last < timedelta(seconds=30):
                 continue
             self._last_alert[idx] = datetime.now()
+            lights = alert.get("lights", []) or []
+            if not lights:
+                _LOGGER.debug(
+                    "Alert %s triggered with no target lights configured; skipping flash service call.",
+                    idx + 1,
+                )
+                continue
             try:
                 await self.hass.services.async_call(
                     DOMAIN,
                     SERVICE_FLASH_LIGHTS,
                     {
                         "power_entity": alert.get("power_entity"),
-                        "lights": alert.get("lights", []),
+                        "lights": lights,
                         "color": (255, 0, 0) if alert.get("flash_mode") == "red" else (255, 255, 255),
                         "duration": alert.get("duration", 10),
                     },
@@ -382,17 +400,22 @@ class HIAutomationEngine:
 
     def _alert_triggered(self, alert: Dict[str, Any]) -> bool:
         ttype = alert.get("trigger_type")
+        room_scope = self._alert_room_scope(alert)
         if ttype == "custom_binary":
             entity_id = alert.get("custom_trigger")
             if entity_id:
                 return self.hass.states.is_state(entity_id, "on")
         if ttype == "condensation_danger":
+            if room_scope:
+                return self._room_condensation_danger(room_scope)
             return self.hass.states.is_state("binary_sensor.hi_condensation_danger", "on")
         if ttype == "mould_danger":
+            if room_scope:
+                return self._room_mould_danger(room_scope)
             return self.hass.states.is_state("binary_sensor.hi_mould_danger", "on")
         if ttype == "humidity_danger":
             threshold = _safe_alert_threshold("humidity_danger", alert.get("threshold"), 75.0)
-            values = self._collect_values("humidity")
+            values = self._collect_values("humidity", room_scope=room_scope)
             return any(val >= threshold for val in values)
         if ttype == "co_emergency":
             threshold = _safe_alert_threshold("co_emergency", alert.get("threshold"), float(CO_EMERGENCY_START))
@@ -728,7 +751,55 @@ class HIAutomationEngine:
             default_threshold = 75.0 if trigger_type == "humidity_danger" else float(CO_EMERGENCY_START)
             threshold = _safe_alert_threshold(trigger_type, threshold, default_threshold)
             threshold_suffix = f" @ {threshold}"
-        return f"Alert {idx + 1}: {trigger_label}{threshold_suffix}"
+        room_scope = self._alert_room_scope(alert)
+        room_suffix = f" in {room_scope}" if room_scope else ""
+        return f"Alert {idx + 1}: {trigger_label}{threshold_suffix}{room_suffix}"
+
+    def _alert_room_scope(self, alert: Dict[str, Any]) -> Optional[str]:
+        trigger_type = str(alert.get("trigger_type") or "")
+        if trigger_type not in ROOM_SCOPED_ALERT_TRIGGERS:
+            return None
+        raw = str(alert.get("room") or "").strip()
+        if not raw:
+            return None
+        raw_key = raw.lower()
+        for item in self.telemetry:
+            room = str(item.get("room") or "").strip()
+            if not room:
+                continue
+            if room.lower() == raw_key:
+                return room
+        return raw
+
+    def _room_condensation_danger(self, room: str) -> bool:
+        rh = self._rooms_avg("humidity", [room])
+        temp = self._rooms_avg("temperature", [room])
+        if rh is None or temp is None:
+            _LOGGER.debug(
+                "Room-scoped condensation alert skipped for %s: missing humidity/temperature telemetry.",
+                room,
+            )
+            return False
+        dp = _dew_point(temp, rh)
+        if dp is None:
+            return False
+        spread = temp - dp
+        return spread <= 2
+
+    def _room_mould_danger(self, room: str) -> bool:
+        rh = self._rooms_avg("humidity", [room])
+        temp = self._rooms_avg("temperature", [room])
+        if rh is None or temp is None:
+            _LOGGER.debug(
+                "Room-scoped mould alert skipped for %s: missing humidity/temperature telemetry.",
+                room,
+            )
+            return False
+        dp = _dew_point(temp, rh)
+        if dp is None:
+            return False
+        spread = temp - dp
+        return _mould_level(rh, spread) >= 3
 
     def _build_runtime_reason(
         self,
@@ -1046,12 +1117,17 @@ class HIAutomationEngine:
             outputs.extend(cfg.get("outputs", []))
         return list(set(outputs))
 
-    def _collect_values(self, sensor_type: str) -> List[float]:
+    def _collect_values(self, sensor_type: str, room_scope: Optional[str] = None) -> List[float]:
         values: List[float] = []
+        room_filter = room_scope.lower().strip() if room_scope else None
         for item in self.telemetry:
             if item.get("sensor_type") != sensor_type:
                 continue
-            val = _get_float(self.hass, item.get("entity_id"))
+            if room_filter:
+                item_room = str(item.get("room") or "").strip().lower()
+                if item_room != room_filter:
+                    continue
+            val = _get_float(self.hass, item.get("entity_id"), sensor_type=sensor_type)
             if val is not None:
                 values.append(val)
         return values
@@ -1063,7 +1139,7 @@ class HIAutomationEngine:
                 continue
             if level and item.get("level") != level:
                 continue
-            val = _get_float(self.hass, item.get("entity_id"))
+            val = _get_float(self.hass, item.get("entity_id"), sensor_type=sensor_type)
             if val is not None:
                 vals.append(val)
         if not vals:
@@ -1081,7 +1157,7 @@ class HIAutomationEngine:
             room = (item.get("room") or "").lower()
             if room not in room_set:
                 continue
-            val = _get_float(self.hass, item.get("entity_id"))
+            val = _get_float(self.hass, item.get("entity_id"), sensor_type=sensor_type)
             if val is not None:
                 vals.append(val)
         if not vals:
@@ -1092,8 +1168,8 @@ class HIAutomationEngine:
         spreads: List[float] = []
         rooms = _room_map(self.telemetry)
         for room, sensors in rooms.items():
-            rh = _get_float(self.hass, sensors.get("humidity"))
-            temp = _get_float(self.hass, sensors.get("temperature"))
+            rh = _get_float(self.hass, sensors.get("humidity"), sensor_type="humidity")
+            temp = _get_float(self.hass, sensors.get("temperature"), sensor_type="temperature")
             if rh is None or temp is None:
                 continue
             dp = _dew_point(temp, rh)
@@ -1106,8 +1182,8 @@ class HIAutomationEngine:
         rooms = _room_map(self.telemetry)
         level = 0
         for room, sensors in rooms.items():
-            rh = _get_float(self.hass, sensors.get("humidity"))
-            temp = _get_float(self.hass, sensors.get("temperature"))
+            rh = _get_float(self.hass, sensors.get("humidity"), sensor_type="humidity")
+            temp = _get_float(self.hass, sensors.get("temperature"), sensor_type="temperature")
             if rh is None or temp is None:
                 continue
             dp = _dew_point(temp, rh)
@@ -1119,16 +1195,28 @@ class HIAutomationEngine:
         return level
 
 
-def _get_float(hass: HomeAssistant, entity_id: Optional[str]) -> Optional[float]:
+def _get_float(
+    hass: HomeAssistant,
+    entity_id: Optional[str],
+    *,
+    sensor_type: Optional[str] = None,
+) -> Optional[float]:
     if not entity_id:
         return None
     state = hass.states.get(entity_id)
-    if state is None or state.state in ("unknown", "unavailable"):
+    if state is None:
         return None
-    try:
-        return float(state.state)
-    except ValueError:
+    raw_state = str(state.state).strip()
+    if raw_state.lower() in ("unknown", "unavailable"):
         return None
+    if sensor_type == "temperature":
+        value_c, _reason = parse_temperature(
+            state.state,
+            state.attributes.get("unit_of_measurement"),
+            hass_temperature_unit(hass),
+        )
+        return value_c
+    return parse_numeric(raw_state)
 
 
 def _room_map(telemetry: List[Dict[str, Any]]) -> Dict[str, Dict[str, str]]:

--- a/config_flow.py
+++ b/config_flow.py
@@ -14,6 +14,7 @@ from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers import selector
 from homeassistant.helpers.selector import SelectOptionDict
 
+from .helpers.zone_validation import detect_zone_mapping_duplicates, summarize_zone_mapping_duplicates
 from .const import (
     DOMAIN,
     DEFAULT_TIME_END,
@@ -33,6 +34,7 @@ from .const import (
     TRIGGER_DEFS,
     AQ_TRIGGER_DEFS,
     ALERT_TRIGGER_DEFS,
+    ROOM_SCOPED_ALERT_TRIGGERS,
     ALERT_THRESHOLD_BOUNDS,
     HUMIDIFIER_BAND_MIN,
     HUMIDIFIER_BAND_MAX,
@@ -107,6 +109,7 @@ class HumidityIntelligenceConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             self._data["engine_interval_minutes"] = user_input.get(
                 "engine_interval_minutes", ENGINE_INTERVAL_MINUTES_DEFAULT
             )
+            self._data["alert_only_mode"] = user_input.get("alert_only_mode", False)
             presence_enabled = user_input.get("enable_presence_gate", False)
             entities = user_input.get("presence_entities", [])
             self._data["presence_gate"] = {
@@ -138,6 +141,7 @@ class HumidityIntelligenceConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     unit_of_measurement="min",
                 )
             ),
+            vol.Optional("alert_only_mode", default=self._data.get("alert_only_mode", False)): selector.BooleanSelector(),
             vol.Optional("enable_presence_gate", default=False): selector.BooleanSelector(),
             vol.Optional("presence_entities", default=[]): selector.EntitySelector(
                 selector.EntitySelectorConfig(multiple=True)
@@ -488,6 +492,13 @@ class HumidityIntelligenceConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             }
             self._zones[zone_key] = zone
             self._data["zones"] = self._zones
+            duplicates = detect_zone_mapping_duplicates(self._telemetry, self._zones)
+            if duplicates:
+                _LOGGER.warning(
+                    "Zone mapping duplicates detected during setup for %s: %s",
+                    zone_key,
+                    summarize_zone_mapping_duplicates(duplicates),
+                )
             if enabled and zone["triggers"]:
                 self._pending_zone_key = zone_key
                 return await self.async_step_zone_thresholds()
@@ -787,38 +798,73 @@ class HumidityIntelligenceConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_alert_add(self, user_input: Optional[Dict[str, Any]] = None):
         """Add a high-priority alert automation."""
-        if user_input is not None:
-            trigger_type = user_input.get("trigger_type")
-            alert: Dict[str, Any] = {
-                "enabled": user_input.get("enabled", False),
-                "trigger_type": trigger_type,
-                "custom_trigger": _sanitize_optional_entity_id(user_input.get("custom_trigger")),
-                "threshold": _safe_alert_threshold(trigger_type, user_input.get("threshold")),
-                "lights": _sanitize_entity_ids(user_input.get("lights", [])),
-                "outputs": _sanitize_entity_ids(user_input.get("outputs", [])),
-                "power_entity": _sanitize_optional_entity_id(user_input.get("power_entity")),
-                "flash_mode": user_input.get("flash_mode"),
-                "duration": user_input.get("duration"),
-            }
-            self._alerts.append(alert)
-            self._data["alerts"] = self._alerts
-            return await self.async_step_alerts()
+        errors: Dict[str, str] = {}
+        telemetry = list(self._telemetry)
 
-        trigger_options = [SelectOptionDict(value=k, label=v["label"]) for k, v in ALERT_TRIGGER_DEFS.items()]
-        default_trigger = trigger_options[0]["value"] if trigger_options else "humidity_danger"
-        threshold_min, threshold_max, threshold_default, threshold_unit = _alert_threshold_bounds(default_trigger)
+        trigger_default = _default_alert_trigger_type()
+        enabled_default = True
+        custom_trigger_default: Optional[str] = None
+        room_default = ""
+        lights_default: List[str] = []
+        outputs_default: List[str] = []
+        power_entity_default: Optional[str] = None
+        flash_mode_default = _default_alert_flash_mode()
+        duration_default = 10
+        threshold_default_value: Any = _safe_alert_threshold(trigger_default, None)
+
+        if user_input is not None:
+            enabled_default = bool(user_input.get("enabled", True))
+            trigger_default = _normalize_alert_trigger_type(user_input.get("trigger_type"))
+            custom_trigger_default = _sanitize_optional_entity_id(user_input.get("custom_trigger"))
+            room_default = _sanitize_optional_room_scope(user_input.get("room")) or ""
+            lights_default = _sanitize_entity_ids(user_input.get("lights", []))
+            outputs_default = _sanitize_entity_ids(user_input.get("outputs", []))
+            power_entity_default = _sanitize_optional_entity_id(user_input.get("power_entity"))
+            flash_mode_default = _normalize_alert_flash_mode(user_input.get("flash_mode"))
+            duration_default = _safe_alert_duration(user_input.get("duration", 10))
+            threshold_default_value = _safe_alert_threshold(trigger_default, user_input.get("threshold"))
+
+            try:
+                if trigger_default == "custom_binary" and not custom_trigger_default:
+                    errors["custom_trigger"] = "custom_trigger_required"
+
+                room_scope, room_error = _resolve_alert_room_scope(telemetry, trigger_default, room_default)
+                if room_error:
+                    errors["room"] = room_error
+
+                if not errors:
+                    alert: Dict[str, Any] = {
+                        "enabled": enabled_default,
+                        "trigger_type": trigger_default,
+                        "custom_trigger": custom_trigger_default,
+                        "threshold": threshold_default_value,
+                        "room": room_scope,
+                        "lights": lights_default,
+                        "outputs": outputs_default,
+                        "power_entity": power_entity_default,
+                        "flash_mode": flash_mode_default,
+                        "duration": duration_default,
+                    }
+                    self._alerts.append(alert)
+                    self._data["alerts"] = self._alerts
+                    return await self.async_step_alerts()
+            except Exception:
+                _LOGGER.exception("Failed to add alert during initial config flow")
+                errors["base"] = "alert_save_failed"
+
+        threshold_min, threshold_max, _, threshold_unit = _alert_threshold_bounds(trigger_default)
         schema = vol.Schema({
-            vol.Optional("enabled", default=True): selector.BooleanSelector(),
-            vol.Required("trigger_type", default=default_trigger): selector.SelectSelector(
+            vol.Optional("enabled", default=enabled_default): selector.BooleanSelector(),
+            vol.Required("trigger_type", default=trigger_default): selector.SelectSelector(
                 selector.SelectSelectorConfig(
-                    options=trigger_options,
+                    options=_alert_trigger_options(),
                     mode=selector.SelectSelectorMode.DROPDOWN,
                 )
             ),
-            vol.Optional("custom_trigger"): selector.EntitySelector(
+            _optional_entity_selector_key("custom_trigger", custom_trigger_default): selector.EntitySelector(
                 selector.EntitySelectorConfig(domain="binary_sensor", multiple=False)
             ),
-            vol.Optional("threshold", default=threshold_default): selector.NumberSelector(
+            vol.Optional("threshold", default=threshold_default_value): selector.NumberSelector(
                 selector.NumberSelectorConfig(
                     min=threshold_min,
                     max=threshold_max,
@@ -826,22 +872,30 @@ class HumidityIntelligenceConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     unit_of_measurement=threshold_unit,
                 )
             ),
-            vol.Optional("lights", default=[]): selector.EntitySelector(
+            vol.Optional("room", default=room_default): selector.SelectSelector(
+                selector.SelectSelectorConfig(
+                    options=_alert_room_options(telemetry),
+                    multiple=False,
+                    custom_value=True,
+                    mode=selector.SelectSelectorMode.DROPDOWN,
+                )
+            ),
+            vol.Optional("lights", default=lights_default): selector.EntitySelector(
                 selector.EntitySelectorConfig(domain="light", multiple=True)
             ),
-            vol.Optional("outputs", default=[]): selector.EntitySelector(
+            vol.Optional("outputs", default=outputs_default): selector.EntitySelector(
                 selector.EntitySelectorConfig(domain=["fan", "switch"], multiple=True)
             ),
-            vol.Optional("power_entity"): selector.EntitySelector(
+            _optional_entity_selector_key("power_entity", power_entity_default): selector.EntitySelector(
                 selector.EntitySelectorConfig(domain=["switch", "light"], multiple=False)
             ),
-            vol.Optional("flash_mode", default=ALERT_FLASH_MODES[0]["value"]): selector.SelectSelector(
+            vol.Optional("flash_mode", default=flash_mode_default): selector.SelectSelector(
                 selector.SelectSelectorConfig(
                     options=[SelectOptionDict(value=o["value"], label=o["label"]) for o in ALERT_FLASH_MODES],
                     mode=selector.SelectSelectorMode.DROPDOWN,
                 )
             ),
-            vol.Optional("duration", default=10): selector.NumberSelector(
+            vol.Optional("duration", default=duration_default): selector.NumberSelector(
                 selector.NumberSelectorConfig(
                     min=ALERT_DURATION_MIN,
                     max=ALERT_DURATION_MAX,
@@ -851,7 +905,7 @@ class HumidityIntelligenceConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 )
             ),
         })
-        return self.async_show_form(step_id="alert_add", data_schema=schema)
+        return self.async_show_form(step_id="alert_add", data_schema=schema, errors=errors)
 
     async def async_step_alerts_done(self, user_input: Optional[Dict[str, Any]] = None):
         return await self.async_step_ui_install()
@@ -1006,6 +1060,7 @@ class HumidityIntelligenceOptionsFlow(config_entries.OptionsFlow):
                 "end": user_input.get("end_time"),
                 "outside_action": user_input.get("outside_action", OUTSIDE_WINDOW_ACTIONS[0]["value"]),
             }
+            self._options["alert_only_mode"] = user_input.get("alert_only_mode", self._section("alert_only_mode", False))
             self._options["engine_interval_minutes"] = user_input.get(
                 "engine_interval_minutes",
                 self._section("engine_interval_minutes", ENGINE_INTERVAL_MINUTES_DEFAULT),
@@ -1053,6 +1108,7 @@ class HumidityIntelligenceOptionsFlow(config_entries.OptionsFlow):
                     unit_of_measurement="min",
                 )
             ),
+            vol.Optional("alert_only_mode", default=self._section("alert_only_mode", False)): selector.BooleanSelector(),
             vol.Optional("enable_presence_gate", default=presence_gate.get("enabled", False)): selector.BooleanSelector(),
             vol.Optional("presence_entities", default=default_presence_entities): selector.EntitySelector(
                 selector.EntitySelectorConfig(multiple=True)
@@ -1179,6 +1235,11 @@ class HumidityIntelligenceOptionsFlow(config_entries.OptionsFlow):
                 telemetry.append(entry)
                 self._options["telemetry"] = telemetry
                 self._sync_slope_after_telemetry_add(entry)
+                _LOGGER.info(
+                    "Added telemetry sensor via options flow: %s (%s)",
+                    entry.get("entity_id"),
+                    entry.get("sensor_type"),
+                )
                 return await self.async_step_options_telemetry()
 
         default_room, default_level = _suggest_room_and_level(
@@ -1244,6 +1305,7 @@ class HumidityIntelligenceOptionsFlow(config_entries.OptionsFlow):
                 removed_entity_id = _sanitize_optional_entity_id(removed.get("entity_id"))
                 if removed_entity_id:
                     self._purge_deleted_telemetry_associations(removed_entity_id, telemetry)
+                    _LOGGER.info("Removed telemetry sensor via options flow: %s", removed_entity_id)
                 return await self.async_step_options_telemetry()
             elif action == "edit":
                 self._pending_telemetry_index = idx
@@ -1284,23 +1346,41 @@ class HumidityIntelligenceOptionsFlow(config_entries.OptionsFlow):
         idx = self._pending_telemetry_index if self._pending_telemetry_index is not None else 0
         idx = max(0, min(idx, len(telemetry) - 1))
         current = telemetry[idx]
+        errors: Dict[str, str] = {}
 
         if user_input is not None:
-            telemetry[idx] = {
-                **current,
-                "entity_id": _sanitize_optional_entity_id(user_input.get("entity_id")) or _sanitize_optional_entity_id(current.get("entity_id")),
-                "friendly_name": user_input.get("friendly_name", current.get("friendly_name", "")),
-                "level": user_input.get("level", current.get("level")),
-                "room": user_input.get("room", current.get("room")),
-            }
-            self._options["telemetry"] = telemetry
-            return await self.async_step_options_telemetry()
+            selected_entity = _sanitize_optional_entity_id(user_input.get("entity_id"))
+            if selected_entity and any(i != idx and item.get("entity_id") == selected_entity for i, item in enumerate(telemetry)):
+                errors["entity_id"] = "duplicate_entity"
+            else:
+                telemetry[idx] = {
+                    **current,
+                    "entity_id": selected_entity or _sanitize_optional_entity_id(current.get("entity_id")),
+                    "sensor_type": user_input.get("sensor_type", current.get("sensor_type", SENSOR_TYPES[0]["value"])),
+                    "friendly_name": user_input.get("friendly_name", current.get("friendly_name", "")),
+                    "level": user_input.get("level", current.get("level")),
+                    "room": user_input.get("room", current.get("room")),
+                }
+                self._options["telemetry"] = telemetry
+                _LOGGER.info(
+                    "Updated telemetry sensor via options flow: %s (%s)",
+                    telemetry[idx].get("entity_id"),
+                    telemetry[idx].get("sensor_type"),
+                )
+                return await self.async_step_options_telemetry()
 
         level_options = [SelectOptionDict(value=o["value"], label=o["label"]) for o in LEVELS]
+        sensor_type_options = [SelectOptionDict(value=o["value"], label=o["label"]) for o in SENSOR_TYPES]
         entity_default = _sanitize_optional_entity_id(current.get("entity_id"))
         schema = vol.Schema({
             vol.Optional("entity_id", default=entity_default): selector.EntitySelector(
                 selector.EntitySelectorConfig(domain="sensor", multiple=False)
+            ),
+            vol.Optional("sensor_type", default=current.get("sensor_type", SENSOR_TYPES[0]["value"])): selector.SelectSelector(
+                selector.SelectSelectorConfig(
+                    options=sensor_type_options,
+                    mode=selector.SelectSelectorMode.DROPDOWN,
+                )
             ),
             vol.Optional("friendly_name", default=current.get("friendly_name", "")): selector.TextSelector(
                 selector.TextSelectorConfig(type=selector.TextSelectorType.TEXT)
@@ -1318,6 +1398,7 @@ class HumidityIntelligenceOptionsFlow(config_entries.OptionsFlow):
         return self.async_show_form(
             step_id="options_telemetry_edit",
             data_schema=schema,
+            errors=errors,
             description_placeholders={
                 "sensor_position": str(idx + 1),
                 "sensor_total": str(len(telemetry)),
@@ -1328,11 +1409,7 @@ class HumidityIntelligenceOptionsFlow(config_entries.OptionsFlow):
     async def async_step_options_zones(self, user_input: Optional[Dict[str, Any]] = None):
         """Choose a zone to edit."""
         zones = dict(self._section("zones", {}))
-        zone_keys = [key for key in ("zone1", "zone2") if key in zones]
-
-        if not zone_keys:
-            schema = vol.Schema({vol.Optional("noop", default=True): selector.BooleanSelector()})
-            return self.async_show_form(step_id="options_zones", data_schema=schema)
+        zone_keys = ["zone1", "zone2"]
 
         if user_input is not None:
             action = user_input.get("action", "done")
@@ -1360,10 +1437,20 @@ class HumidityIntelligenceOptionsFlow(config_entries.OptionsFlow):
 
     async def async_step_options_zone_edit(self, user_input: Optional[Dict[str, Any]] = None):
         zones = dict(self._section("zones", {}))
-        zone_key = self._pending_zone_key or ("zone1" if "zone1" in zones else "zone2")
-        zone = zones.get(zone_key)
-        if not zone:
-            return await self.async_step_options_zones()
+        zone_key = self._pending_zone_key or "zone1"
+        configured_levels = _configured_levels(self._section("telemetry", []))
+        default_level = configured_levels[0] if configured_levels else LEVELS[0]["value"]
+        zone = zones.get(zone_key) or {
+            "enabled": False,
+            "level": default_level,
+            "rooms": [],
+            "triggers": [],
+            "outputs": [],
+            "output_level": ZONE_OUTPUT_LEVEL_DEFAULT,
+            "boost_output_level": ZONE_OUTPUT_LEVEL_BOOST_DEFAULT,
+            "ui_label": _default_zone_ui_label(zone_key),
+            "thresholds": {},
+        }
 
         selected_triggers = [
             trig for trig in (zone.get("triggers", []) or []) if trig in TRIGGER_DEFS
@@ -1405,6 +1492,13 @@ class HumidityIntelligenceOptionsFlow(config_entries.OptionsFlow):
                 "thresholds": thresholds,
             }
             self._options["zones"] = zones
+            duplicates = detect_zone_mapping_duplicates(self._section("telemetry", []), zones)
+            if duplicates:
+                _LOGGER.warning(
+                    "Zone mapping duplicates detected in options for %s: %s",
+                    zone_key,
+                    summarize_zone_mapping_duplicates(duplicates),
+                )
             return await self.async_step_options_zones()
 
         room_options = [SelectOptionDict(value=room, label=room) for room in _rooms_all(self._section("telemetry", []))]
@@ -1488,14 +1582,11 @@ class HumidityIntelligenceOptionsFlow(config_entries.OptionsFlow):
     async def async_step_options_humidifiers(self, user_input: Optional[Dict[str, Any]] = None):
         """Choose a humidifier lane to edit."""
         humidifiers = dict(self._section("humidifiers", {}))
-        levels = sorted(humidifiers.keys())
+        configured_levels = set(_configured_levels(self._section("telemetry", [])))
+        known_levels = {item["value"] for item in LEVELS}
+        levels = sorted(set(humidifiers.keys()).union(configured_levels).union(known_levels))
         if not levels:
-            schema = vol.Schema({vol.Optional("noop", default=True): selector.BooleanSelector()})
-            return self.async_show_form(
-                step_id="options_humidifiers",
-                data_schema=schema,
-                description_placeholders={"configured_humidifiers": "No humidifier lanes are configured yet."},
-            )
+            levels = [LEVELS[0]["value"]]
 
         if user_input is not None:
             action = user_input.get("action", "done")
@@ -1505,7 +1596,17 @@ class HumidityIntelligenceOptionsFlow(config_entries.OptionsFlow):
                 self._pending_humidifier_level = action
                 return await self.async_step_options_humidifier_edit()
 
-        options = [SelectOptionDict(value=level, label=_level_choice_label(level)) for level in levels]
+        options = [
+            SelectOptionDict(
+                value=level,
+                label=(
+                    f"{_level_choice_label(level)}"
+                    if level in humidifiers
+                    else f"{_level_choice_label(level)} (not configured - select to add)"
+                ),
+            )
+            for level in levels
+        ]
         options.append(SelectOptionDict(value="done", label="Done"))
         schema = vol.Schema({
             vol.Required("action", default=levels[0]): selector.SelectSelector(
@@ -1524,11 +1625,17 @@ class HumidityIntelligenceOptionsFlow(config_entries.OptionsFlow):
     async def async_step_options_humidifier_edit(self, user_input: Optional[Dict[str, Any]] = None):
         humidifiers = dict(self._section("humidifiers", {}))
         level = self._pending_humidifier_level or (sorted(humidifiers.keys())[0] if humidifiers else None)
-        if not level or level not in humidifiers:
+        if not level:
             return await self.async_step_options_humidifiers()
-        cfg = humidifiers[level]
+        cfg = humidifiers.get(level, {"enabled": False, "band_adjust": 0, "outputs": []})
+        lane_existed = level in humidifiers
 
         if user_input is not None:
+            if user_input.get("remove_lane", False):
+                humidifiers.pop(level, None)
+                self._options["humidifiers"] = humidifiers
+                _LOGGER.info("Removed humidifier lane for %s via options flow", level)
+                return await self.async_step_options_humidifiers()
             humidifiers[level] = {
                 **cfg,
                 "enabled": user_input.get("enabled", cfg.get("enabled", True)),
@@ -1536,9 +1643,14 @@ class HumidityIntelligenceOptionsFlow(config_entries.OptionsFlow):
                 "outputs": _sanitize_entity_ids(user_input.get("outputs", cfg.get("outputs", []))),
             }
             self._options["humidifiers"] = humidifiers
+            if lane_existed:
+                _LOGGER.info("Updated humidifier lane for %s via options flow", level)
+            else:
+                _LOGGER.info("Added humidifier lane for %s via options flow", level)
             return await self.async_step_options_humidifiers()
 
         schema = vol.Schema({
+            vol.Optional("remove_lane", default=False): selector.BooleanSelector(),
             vol.Optional("enabled", default=cfg.get("enabled", True)): selector.BooleanSelector(),
             vol.Optional("band_adjust", default=cfg.get("band_adjust", 0)): selector.NumberSelector(
                 selector.NumberSelectorConfig(
@@ -1562,14 +1674,12 @@ class HumidityIntelligenceOptionsFlow(config_entries.OptionsFlow):
     async def async_step_options_aq(self, user_input: Optional[Dict[str, Any]] = None):
         """Choose an AQ lane to edit."""
         aq = dict(self._section("aq", {}))
-        levels = sorted(aq.keys())
+        configured_levels = set(_levels_with_aq(self._section("telemetry", [])))
+        telemetry_levels = set(_configured_levels(self._section("telemetry", [])))
+        known_levels = {item["value"] for item in LEVELS}
+        levels = sorted(set(aq.keys()).union(configured_levels).union(telemetry_levels).union(known_levels))
         if not levels:
-            schema = vol.Schema({vol.Optional("noop", default=True): selector.BooleanSelector()})
-            return self.async_show_form(
-                step_id="options_aq",
-                data_schema=schema,
-                description_placeholders={"configured_aq": "No AQ lanes are configured yet."},
-            )
+            levels = _configured_levels(self._section("telemetry", [])) or [LEVELS[0]["value"]]
 
         if user_input is not None:
             action = user_input.get("action", "done")
@@ -1579,7 +1689,17 @@ class HumidityIntelligenceOptionsFlow(config_entries.OptionsFlow):
                 self._pending_aq_level = action
                 return await self.async_step_options_aq_edit()
 
-        options = [SelectOptionDict(value=level, label=_level_choice_label(level)) for level in levels]
+        options = [
+            SelectOptionDict(
+                value=level,
+                label=(
+                    f"{_level_choice_label(level)}"
+                    if level in aq
+                    else f"{_level_choice_label(level)} (not configured - select to add)"
+                ),
+            )
+            for level in levels
+        ]
         options.append(SelectOptionDict(value="done", label="Done"))
         schema = vol.Schema({
             vol.Required("action", default=levels[0]): selector.SelectSelector(
@@ -1598,11 +1718,24 @@ class HumidityIntelligenceOptionsFlow(config_entries.OptionsFlow):
     async def async_step_options_aq_edit(self, user_input: Optional[Dict[str, Any]] = None):
         aq = dict(self._section("aq", {}))
         level = self._pending_aq_level or (sorted(aq.keys())[0] if aq else None)
-        if not level or level not in aq:
+        if not level:
             return await self.async_step_options_aq()
-        cfg = aq[level]
+        cfg = aq.get(level, {
+            "enabled": False,
+            "triggers": [],
+            "outputs": [],
+            "run_duration": 30,
+            "output_level": ZONE_OUTPUT_LEVEL_DEFAULT,
+            "thresholds": {},
+        })
+        lane_existed = level in aq
 
         if user_input is not None:
+            if user_input.get("remove_lane", False):
+                aq.pop(level, None)
+                self._options["aq"] = aq
+                _LOGGER.info("Removed AQ lane for %s via options flow", level)
+                return await self.async_step_options_aq()
             selected_triggers = user_input.get("triggers", cfg.get("triggers", [])) or []
             thresholds = dict(cfg.get("thresholds", {}))
             for trig in selected_triggers:
@@ -1622,10 +1755,15 @@ class HumidityIntelligenceOptionsFlow(config_entries.OptionsFlow):
                 "thresholds": thresholds,
             }
             self._options["aq"] = aq
+            if lane_existed:
+                _LOGGER.info("Updated AQ lane for %s via options flow", level)
+            else:
+                _LOGGER.info("Added AQ lane for %s via options flow", level)
             return await self.async_step_options_aq()
 
         selected_triggers = cfg.get("triggers", []) or []
         schema_fields: Dict[Any, Any] = {
+            vol.Optional("remove_lane", default=False): selector.BooleanSelector(),
             vol.Optional("enabled", default=cfg.get("enabled", False)): selector.BooleanSelector(),
             vol.Optional("triggers", default=selected_triggers): selector.SelectSelector(
                 selector.SelectSelectorConfig(
@@ -1683,14 +1821,13 @@ class HumidityIntelligenceOptionsFlow(config_entries.OptionsFlow):
     async def async_step_options_alerts(self, user_input: Optional[Dict[str, Any]] = None):
         """Choose an alert to edit."""
         alerts = list(self._section("alerts", []))
-        if not alerts:
-            schema = vol.Schema({vol.Optional("noop", default=True): selector.BooleanSelector()})
-            return self.async_show_form(step_id="options_alerts", data_schema=schema)
 
         if user_input is not None:
             action = user_input.get("action", "done")
             if action == "done":
                 return await self.async_step_init()
+            if action == "add":
+                return await self.async_step_options_alert_add()
             try:
                 idx = int(action)
             except (TypeError, ValueError):
@@ -1699,13 +1836,15 @@ class HumidityIntelligenceOptionsFlow(config_entries.OptionsFlow):
                 self._pending_alert_index = idx
                 return await self.async_step_options_alert_edit()
 
-        options = [
+        options = [SelectOptionDict(value="add", label="Add alert")]
+        options.extend([
             SelectOptionDict(value=str(idx), label=_alert_option_label(idx, alert))
             for idx, alert in enumerate(alerts)
-        ]
+        ])
         options.append(SelectOptionDict(value="done", label="Done"))
+        default_action = "0" if alerts else "add"
         schema = vol.Schema({
-            vol.Required("action", default="0"): selector.SelectSelector(
+            vol.Required("action", default=default_action): selector.SelectSelector(
                 selector.SelectSelectorConfig(
                     options=options,
                     mode=selector.SelectSelectorMode.DROPDOWN,
@@ -1718,6 +1857,120 @@ class HumidityIntelligenceOptionsFlow(config_entries.OptionsFlow):
             description_placeholders={"configured_alerts": _render_alerts_summary(alerts)},
         )
 
+    async def async_step_options_alert_add(self, user_input: Optional[Dict[str, Any]] = None):
+        """Add a new alert from options."""
+        alerts = list(self._section("alerts", []))
+        if len(alerts) >= MAX_ALERTS:
+            return await self.async_step_options_alerts()
+        errors: Dict[str, str] = {}
+        telemetry = list(self._section("telemetry", []))
+
+        trigger_default = _default_alert_trigger_type()
+        enabled_default = True
+        custom_trigger_default: Optional[str] = None
+        room_default = ""
+        lights_default: List[str] = []
+        outputs_default: List[str] = []
+        power_entity_default: Optional[str] = None
+        flash_mode_default = _default_alert_flash_mode()
+        duration_default = 10
+        threshold_default_value: Any = _safe_alert_threshold(trigger_default, None)
+
+        if user_input is not None:
+            enabled_default = bool(user_input.get("enabled", True))
+            trigger_default = _normalize_alert_trigger_type(user_input.get("trigger_type"))
+            custom_trigger_default = _sanitize_optional_entity_id(user_input.get("custom_trigger"))
+            room_default = _sanitize_optional_room_scope(user_input.get("room")) or ""
+            lights_default = _sanitize_entity_ids(user_input.get("lights", []))
+            outputs_default = _sanitize_entity_ids(user_input.get("outputs", []))
+            power_entity_default = _sanitize_optional_entity_id(user_input.get("power_entity"))
+            flash_mode_default = _normalize_alert_flash_mode(user_input.get("flash_mode"))
+            duration_default = _safe_alert_duration(user_input.get("duration", 10))
+            threshold_default_value = _safe_alert_threshold(trigger_default, user_input.get("threshold"))
+
+            try:
+                if trigger_default == "custom_binary" and not custom_trigger_default:
+                    errors["custom_trigger"] = "custom_trigger_required"
+
+                room_scope, room_error = _resolve_alert_room_scope(telemetry, trigger_default, room_default)
+                if room_error:
+                    errors["room"] = room_error
+
+                if not errors:
+                    alert = {
+                        "enabled": enabled_default,
+                        "trigger_type": trigger_default,
+                        "custom_trigger": custom_trigger_default,
+                        "threshold": threshold_default_value,
+                        "room": room_scope,
+                        "lights": lights_default,
+                        "outputs": outputs_default,
+                        "power_entity": power_entity_default,
+                        "flash_mode": flash_mode_default,
+                        "duration": duration_default,
+                    }
+                    alerts.append(alert)
+                    self._options["alerts"] = alerts
+                    return await self.async_step_options_alerts()
+            except Exception:
+                _LOGGER.exception("Failed to add alert in options flow")
+                errors["base"] = "alert_save_failed"
+
+        threshold_min, threshold_max, _, threshold_unit = _alert_threshold_bounds(trigger_default)
+        schema = vol.Schema({
+            vol.Optional("enabled", default=enabled_default): selector.BooleanSelector(),
+            vol.Required("trigger_type", default=trigger_default): selector.SelectSelector(
+                selector.SelectSelectorConfig(
+                    options=_alert_trigger_options(),
+                    mode=selector.SelectSelectorMode.DROPDOWN,
+                )
+            ),
+            _optional_entity_selector_key("custom_trigger", custom_trigger_default): selector.EntitySelector(
+                selector.EntitySelectorConfig(domain="binary_sensor", multiple=False)
+            ),
+            vol.Optional("threshold", default=threshold_default_value): selector.NumberSelector(
+                selector.NumberSelectorConfig(
+                    min=threshold_min,
+                    max=threshold_max,
+                    step=1,
+                    unit_of_measurement=threshold_unit,
+                )
+            ),
+            vol.Optional("room", default=room_default): selector.SelectSelector(
+                selector.SelectSelectorConfig(
+                    options=_alert_room_options(telemetry),
+                    multiple=False,
+                    custom_value=True,
+                    mode=selector.SelectSelectorMode.DROPDOWN,
+                )
+            ),
+            vol.Optional("lights", default=lights_default): selector.EntitySelector(
+                selector.EntitySelectorConfig(domain="light", multiple=True)
+            ),
+            vol.Optional("outputs", default=outputs_default): selector.EntitySelector(
+                selector.EntitySelectorConfig(domain=["fan", "switch"], multiple=True)
+            ),
+            _optional_entity_selector_key("power_entity", power_entity_default): selector.EntitySelector(
+                selector.EntitySelectorConfig(domain=["switch", "light"], multiple=False)
+            ),
+            vol.Optional("flash_mode", default=flash_mode_default): selector.SelectSelector(
+                selector.SelectSelectorConfig(
+                    options=[SelectOptionDict(value=o["value"], label=o["label"]) for o in ALERT_FLASH_MODES],
+                    mode=selector.SelectSelectorMode.DROPDOWN,
+                )
+            ),
+            vol.Optional("duration", default=duration_default): selector.NumberSelector(
+                selector.NumberSelectorConfig(
+                    min=ALERT_DURATION_MIN,
+                    max=ALERT_DURATION_MAX,
+                    step=ALERT_DURATION_STEP,
+                    mode=selector.NumberSelectorMode.SLIDER,
+                    unit_of_measurement="s",
+                )
+            ),
+        })
+        return self.async_show_form(step_id="options_alert_add", data_schema=schema, errors=errors)
+
     async def async_step_options_alert_edit(self, user_input: Optional[Dict[str, Any]] = None):
         alerts = list(self._section("alerts", []))
         if not alerts:
@@ -1726,51 +1979,82 @@ class HumidityIntelligenceOptionsFlow(config_entries.OptionsFlow):
         idx = self._pending_alert_index if self._pending_alert_index is not None else 0
         idx = max(0, min(idx, len(alerts) - 1))
         alert = alerts[idx]
-        trigger_type = alert.get("trigger_type")
-        threshold_min, threshold_max, threshold_default, threshold_unit = _alert_threshold_bounds(trigger_type)
-        default_threshold = _safe_alert_threshold(
-            trigger_type,
-            alert.get("threshold", threshold_default),
-        )
+        telemetry = list(self._section("telemetry", []))
+        errors: Dict[str, str] = {}
+
+        trigger_default = _normalize_alert_trigger_type(alert.get("trigger_type"))
+        enabled_default = bool(alert.get("enabled", True))
+        custom_trigger_default = _sanitize_optional_entity_id(alert.get("custom_trigger"))
+        room_default = _sanitize_optional_room_scope(alert.get("room")) or ""
+        lights_default = _sanitize_entity_ids(alert.get("lights", []))
+        outputs_default = _sanitize_entity_ids(alert.get("outputs", []))
+        power_entity_default = _sanitize_optional_entity_id(alert.get("power_entity"))
+        flash_mode_default = _normalize_alert_flash_mode(alert.get("flash_mode"))
+        duration_default = _safe_alert_duration(alert.get("duration", 10))
+        threshold_default = _safe_alert_threshold(trigger_default, alert.get("threshold"))
 
         if user_input is not None:
-            selected_trigger_type = user_input.get("trigger_type", alert.get("trigger_type"))
-            alerts[idx] = {
-                **alert,
-                "enabled": user_input.get("enabled", alert.get("enabled", True)),
-                "trigger_type": selected_trigger_type,
-                "custom_trigger": _sanitize_optional_entity_id(
-                    user_input.get("custom_trigger", alert.get("custom_trigger"))
-                ),
-                "threshold": _safe_alert_threshold(
-                    selected_trigger_type,
-                    user_input.get("threshold", alert.get("threshold")),
-                ),
-                "lights": _sanitize_entity_ids(user_input.get("lights", alert.get("lights", []))),
-                "outputs": _sanitize_entity_ids(user_input.get("outputs", alert.get("outputs", []))),
-                "power_entity": _sanitize_optional_entity_id(
-                    user_input.get("power_entity", alert.get("power_entity"))
-                ),
-                "flash_mode": user_input.get("flash_mode", alert.get("flash_mode")),
-                "duration": user_input.get("duration", alert.get("duration", 10)),
-            }
-            self._options["alerts"] = alerts
-            return await self.async_step_options_alerts()
+            trigger_default = _normalize_alert_trigger_type(user_input.get("trigger_type", trigger_default))
+            enabled_default = bool(user_input.get("enabled", enabled_default))
+            custom_trigger_default = _sanitize_optional_entity_id(
+                user_input.get("custom_trigger", custom_trigger_default)
+            )
+            room_default = _sanitize_optional_room_scope(user_input.get("room", room_default)) or ""
+            lights_default = _sanitize_entity_ids(user_input.get("lights", lights_default))
+            outputs_default = _sanitize_entity_ids(user_input.get("outputs", outputs_default))
+            power_entity_default = _sanitize_optional_entity_id(
+                user_input.get("power_entity", power_entity_default)
+            )
+            flash_mode_default = _normalize_alert_flash_mode(
+                user_input.get("flash_mode", flash_mode_default)
+            )
+            duration_default = _safe_alert_duration(user_input.get("duration", duration_default))
+            threshold_default = _safe_alert_threshold(
+                trigger_default,
+                user_input.get("threshold", threshold_default),
+            )
 
-        custom_trigger_default = _sanitize_optional_entity_id(alert.get("custom_trigger"))
-        power_entity_default = _sanitize_optional_entity_id(alert.get("power_entity"))
+            try:
+                if trigger_default == "custom_binary" and not custom_trigger_default:
+                    errors["custom_trigger"] = "custom_trigger_required"
+
+                room_scope, room_error = _resolve_alert_room_scope(telemetry, trigger_default, room_default)
+                if room_error:
+                    errors["room"] = room_error
+
+                if not errors:
+                    alerts[idx] = {
+                        **alert,
+                        "enabled": enabled_default,
+                        "trigger_type": trigger_default,
+                        "custom_trigger": custom_trigger_default,
+                        "threshold": threshold_default,
+                        "room": room_scope,
+                        "lights": lights_default,
+                        "outputs": outputs_default,
+                        "power_entity": power_entity_default,
+                        "flash_mode": flash_mode_default,
+                        "duration": duration_default,
+                    }
+                    self._options["alerts"] = alerts
+                    return await self.async_step_options_alerts()
+            except Exception:
+                _LOGGER.exception("Failed to edit alert %s in options flow", idx + 1)
+                errors["base"] = "alert_save_failed"
+
+        threshold_min, threshold_max, _, threshold_unit = _alert_threshold_bounds(trigger_default)
         schema = vol.Schema({
-            vol.Optional("enabled", default=alert.get("enabled", True)): selector.BooleanSelector(),
-            vol.Optional("trigger_type", default=alert.get("trigger_type")): selector.SelectSelector(
+            vol.Optional("enabled", default=enabled_default): selector.BooleanSelector(),
+            vol.Optional("trigger_type", default=trigger_default): selector.SelectSelector(
                 selector.SelectSelectorConfig(
-                    options=[SelectOptionDict(value=k, label=v["label"]) for k, v in ALERT_TRIGGER_DEFS.items()],
+                    options=_alert_trigger_options(),
                     mode=selector.SelectSelectorMode.DROPDOWN,
                 )
             ),
             _optional_entity_selector_key("custom_trigger", custom_trigger_default): selector.EntitySelector(
                 selector.EntitySelectorConfig(domain="binary_sensor", multiple=False)
             ),
-            vol.Optional("threshold", default=default_threshold): selector.NumberSelector(
+            vol.Optional("threshold", default=threshold_default): selector.NumberSelector(
                 selector.NumberSelectorConfig(
                     min=threshold_min,
                     max=threshold_max,
@@ -1778,22 +2062,30 @@ class HumidityIntelligenceOptionsFlow(config_entries.OptionsFlow):
                     unit_of_measurement=threshold_unit,
                 )
             ),
-            vol.Optional("lights", default=_sanitize_entity_ids(alert.get("lights", []))): selector.EntitySelector(
+            vol.Optional("room", default=room_default): selector.SelectSelector(
+                selector.SelectSelectorConfig(
+                    options=_alert_room_options(telemetry),
+                    multiple=False,
+                    custom_value=True,
+                    mode=selector.SelectSelectorMode.DROPDOWN,
+                )
+            ),
+            vol.Optional("lights", default=lights_default): selector.EntitySelector(
                 selector.EntitySelectorConfig(domain="light", multiple=True)
             ),
-            vol.Optional("outputs", default=_sanitize_entity_ids(alert.get("outputs", []))): selector.EntitySelector(
+            vol.Optional("outputs", default=outputs_default): selector.EntitySelector(
                 selector.EntitySelectorConfig(domain=["fan", "switch"], multiple=True)
             ),
             _optional_entity_selector_key("power_entity", power_entity_default): selector.EntitySelector(
                 selector.EntitySelectorConfig(domain=["switch", "light"], multiple=False)
             ),
-            vol.Optional("flash_mode", default=alert.get("flash_mode")): selector.SelectSelector(
+            vol.Optional("flash_mode", default=flash_mode_default): selector.SelectSelector(
                 selector.SelectSelectorConfig(
                     options=[SelectOptionDict(value=o["value"], label=o["label"]) for o in ALERT_FLASH_MODES],
                     mode=selector.SelectSelectorMode.DROPDOWN,
                 )
             ),
-            vol.Optional("duration", default=alert.get("duration", 10)): selector.NumberSelector(
+            vol.Optional("duration", default=duration_default): selector.NumberSelector(
                 selector.NumberSelectorConfig(
                     min=ALERT_DURATION_MIN,
                     max=ALERT_DURATION_MAX,
@@ -1806,6 +2098,7 @@ class HumidityIntelligenceOptionsFlow(config_entries.OptionsFlow):
         return self.async_show_form(
             step_id="options_alert_edit",
             data_schema=schema,
+            errors=errors,
             description_placeholders={"alert_label": _alert_option_label(idx, alert)},
         )
 
@@ -1921,7 +2214,10 @@ def _sanitize_optional_entity_id(value: Any) -> Optional[str]:
 def _sanitize_entity_ids(values: Any) -> List[str]:
     if not values:
         return []
-    raw = values if isinstance(values, list) else [values]
+    if isinstance(values, (list, tuple, set)):
+        raw = list(values)
+    else:
+        raw = [values]
     result: List[str] = []
     seen = set()
     for item in raw:
@@ -1990,6 +2286,106 @@ def _safe_alert_threshold(trigger_type: Any, value: Any) -> Any:
     return round(parsed, 2)
 
 
+def _default_alert_trigger_type() -> str:
+    if ALERT_TRIGGER_DEFS:
+        return next(iter(ALERT_TRIGGER_DEFS.keys()))
+    return "humidity_danger"
+
+
+def _normalize_alert_trigger_type(value: Any) -> str:
+    text = str(value or "").strip()
+    if text in ALERT_TRIGGER_DEFS:
+        return text
+    return _default_alert_trigger_type()
+
+
+def _alert_trigger_options() -> List[SelectOptionDict]:
+    return [SelectOptionDict(value=k, label=v["label"]) for k, v in ALERT_TRIGGER_DEFS.items()]
+
+
+def _default_alert_flash_mode() -> str:
+    if ALERT_FLASH_MODES:
+        return str(ALERT_FLASH_MODES[0]["value"])
+    return "red"
+
+
+def _normalize_alert_flash_mode(value: Any) -> str:
+    text = str(value or "").strip()
+    valid = {str(item["value"]) for item in ALERT_FLASH_MODES}
+    if text in valid:
+        return text
+    return _default_alert_flash_mode()
+
+
+def _safe_alert_duration(value: Any, default: int = 10) -> int:
+    try:
+        parsed = int(float(value))
+    except (TypeError, ValueError):
+        parsed = int(default)
+    return max(ALERT_DURATION_MIN, min(ALERT_DURATION_MAX, parsed))
+
+
+def _sanitize_optional_room_scope(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    return text
+
+
+def _alert_room_options(telemetry: List[Dict[str, Any]]) -> List[SelectOptionDict]:
+    return [SelectOptionDict(value=room, label=room) for room in _rooms_all(telemetry)]
+
+
+def _resolve_alert_room_scope(
+    telemetry: List[Dict[str, Any]],
+    trigger_type: str,
+    room_value: Any,
+) -> Tuple[Optional[str], Optional[str]]:
+    room_scope = _sanitize_optional_room_scope(room_value)
+    if not room_scope:
+        return None, None
+
+    if trigger_type not in ROOM_SCOPED_ALERT_TRIGGERS:
+        return None, None
+
+    room_lookup = {}
+    for room in _rooms_all(telemetry):
+        key = room.lower().strip()
+        if key and key not in room_lookup:
+            room_lookup[key] = room
+    resolved_room = room_lookup.get(room_scope.lower().strip())
+    if not resolved_room:
+        return None, "room_unknown"
+
+    if trigger_type == "humidity_danger":
+        if not _telemetry_room_has_sensor_type(telemetry, resolved_room, "humidity"):
+            return None, "room_missing_humidity"
+    elif trigger_type in {"condensation_danger", "mould_danger"}:
+        has_humidity = _telemetry_room_has_sensor_type(telemetry, resolved_room, "humidity")
+        has_temperature = _telemetry_room_has_sensor_type(telemetry, resolved_room, "temperature")
+        if not has_humidity or not has_temperature:
+            return None, "room_missing_temp_humidity"
+
+    return resolved_room, None
+
+
+def _telemetry_room_has_sensor_type(
+    telemetry: List[Dict[str, Any]],
+    room: str,
+    sensor_type: str,
+) -> bool:
+    room_key = room.lower().strip()
+    for item in telemetry:
+        item_room = str(item.get("room") or "").strip().lower()
+        if not item_room or item_room != room_key:
+            continue
+        if item.get("sensor_type") == sensor_type and _sanitize_optional_entity_id(item.get("entity_id")):
+            return True
+    return False
+
+
 def _optional_entity_selector_key(field_name: str, default_value: Any) -> Any:
     entity_id = _sanitize_optional_entity_id(default_value)
     if entity_id is None:
@@ -2010,7 +2406,9 @@ def _render_alerts_summary(alerts: List[Dict[str, Any]]) -> str:
         suffix = ""
         if threshold not in (None, ""):
             suffix = f" @ {threshold}"
-        lines.append(f"- Alert {idx}: {trigger_label}{suffix}")
+        room_scope = _sanitize_optional_room_scope(alert.get("room"))
+        room_suffix = f" in {room_scope}" if room_scope else ""
+        lines.append(f"- Alert {idx}: {trigger_label}{suffix}{room_suffix}")
     return "\n".join(lines)
 
 
@@ -2137,7 +2535,9 @@ def _alert_option_label(idx: int, alert: Dict[str, Any]) -> str:
     trigger = str(alert.get("trigger_type") or "unknown")
     trigger_label = ALERT_TRIGGER_DEFS.get(trigger, {}).get("label", trigger.replace("_", " ").title())
     enabled = "Enabled" if alert.get("enabled", True) else "Disabled"
-    return f"Alert {idx + 1} - {trigger_label} ({enabled})"
+    room_scope = _sanitize_optional_room_scope(alert.get("room"))
+    room_suffix = f" in {room_scope}" if room_scope else ""
+    return f"Alert {idx + 1} - {trigger_label}{room_suffix} ({enabled})"
 
 
 def _suggest_room_and_level(hass: HomeAssistant, entity_id: str | None = None) -> tuple[str, str]:

--- a/const.py
+++ b/const.py
@@ -131,6 +131,13 @@ ALERT_TRIGGER_DEFS = {
     "custom_binary": {"label": "Custom binary sensor"},
 }
 
+# Alert trigger types that support room-scoped evaluation.
+ROOM_SCOPED_ALERT_TRIGGERS = (
+    "humidity_danger",
+    "condensation_danger",
+    "mould_danger",
+)
+
 # Safety guardrails for alert thresholds.
 # These are enforced in config/options flow and at runtime as a fallback.
 ALERT_THRESHOLD_BOUNDS = {

--- a/helpers/parsing.py
+++ b/helpers/parsing.py
@@ -1,0 +1,107 @@
+"""Parsing helpers for telemetry normalization and unit safety."""
+
+from __future__ import annotations
+
+import math
+import re
+from typing import Any, Optional, Tuple
+
+from homeassistant.const import UnitOfTemperature
+
+_UNKNOWN_STATE_VALUES = {"", "unknown", "unavailable", "none", "null"}
+_NUMBER_RE = re.compile(r"[-+]?\d*\.?\d+(?:[eE][-+]?\d+)?")
+
+_TEMP_UNIT_C = {
+    "c",
+    "degc",
+    "celsius",
+    "°c",
+    str(UnitOfTemperature.CELSIUS).lower(),
+}
+_TEMP_UNIT_F = {
+    "f",
+    "degf",
+    "fahrenheit",
+    "°f",
+    str(UnitOfTemperature.FAHRENHEIT).lower(),
+}
+
+
+def parse_numeric(value: Any) -> Optional[float]:
+    """Parse a numeric value from scalar/string telemetry."""
+    if isinstance(value, bool):
+        return None
+
+    if isinstance(value, (int, float)):
+        parsed = float(value)
+        return parsed if math.isfinite(parsed) else None
+
+    text = str(value).strip()
+    if text.lower() in _UNKNOWN_STATE_VALUES:
+        return None
+
+    text = text.replace(",", "")
+    try:
+        parsed = float(text)
+    except (TypeError, ValueError):
+        match = _NUMBER_RE.search(text)
+        if not match:
+            return None
+        try:
+            parsed = float(match.group(0))
+        except (TypeError, ValueError):
+            return None
+
+    return parsed if math.isfinite(parsed) else None
+
+
+def normalize_temperature_unit(unit: Any) -> Optional[str]:
+    """Normalize temperature unit text to 'celsius' or 'fahrenheit'."""
+    if unit is None:
+        return None
+    text = str(unit).strip().lower()
+    if text in _TEMP_UNIT_C:
+        return "celsius"
+    if text in _TEMP_UNIT_F:
+        return "fahrenheit"
+    return None
+
+
+def hass_temperature_unit(hass: Any) -> str:
+    """Return HA configured temperature unit, defaulting to Celsius."""
+    configured = (
+        getattr(getattr(getattr(hass, "config", None), "units", None), "temperature_unit", None)
+    )
+    normalized = normalize_temperature_unit(configured)
+    if normalized == "fahrenheit":
+        return str(UnitOfTemperature.FAHRENHEIT)
+    return str(UnitOfTemperature.CELSIUS)
+
+
+def parse_temperature(
+    value: Any,
+    unit: Any = None,
+    fallback_unit: Any = None,
+) -> Tuple[Optional[float], Optional[str]]:
+    """Parse incoming temperature and normalize to Celsius."""
+    parsed = parse_numeric(value)
+    if parsed is None:
+        return None, "non_numeric"
+
+    normalized = normalize_temperature_unit(unit) or normalize_temperature_unit(fallback_unit)
+    if normalized is None:
+        return None, "unit_mismatch"
+
+    if normalized == "fahrenheit":
+        return (parsed - 32.0) * (5.0 / 9.0), None
+    return parsed, None
+
+
+def format_temperature(value_c: Optional[float], display_unit: Any) -> Optional[float]:
+    """Format Celsius value into display unit for diagnostics/UI rendering."""
+    if value_c is None:
+        return None
+    normalized = normalize_temperature_unit(display_unit) or "celsius"
+    if normalized == "fahrenheit":
+        return round((value_c * 9.0 / 5.0) + 32.0, 1)
+    return round(value_c, 1)

--- a/helpers/zone_validation.py
+++ b/helpers/zone_validation.py
@@ -1,0 +1,71 @@
+"""Zone mapping validation helpers."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Set
+
+_TRACKED_SENSOR_TYPES = {"humidity", "temperature", "iaq", "pm25", "voc", "co2", "co"}
+
+
+def detect_zone_mapping_duplicates(
+    telemetry: List[Dict[str, Any]],
+    zones: Dict[str, Dict[str, Any]],
+) -> Dict[str, List[str]]:
+    """Find overlapping telemetry entity mappings across enabled zones."""
+    zone_sources: Dict[str, Set[str]] = {}
+    for zone_key in ("zone1", "zone2"):
+        zone_cfg = zones.get(zone_key)
+        if not isinstance(zone_cfg, dict):
+            continue
+        if not zone_cfg.get("enabled"):
+            continue
+        zone_sources[zone_key] = _zone_sensor_sources(telemetry, zone_cfg)
+
+    duplicates: Dict[str, List[str]] = {}
+    keys = sorted(zone_sources.keys())
+    for idx, left in enumerate(keys):
+        for right in keys[idx + 1 :]:
+            overlap = sorted(zone_sources[left].intersection(zone_sources[right]))
+            if overlap:
+                duplicates[f"{left}:{right}"] = overlap
+    return duplicates
+
+
+def summarize_zone_mapping_duplicates(duplicates: Dict[str, List[str]]) -> str:
+    """Create a concise warning string for duplicate zone mappings."""
+    if not duplicates:
+        return ""
+    sections: List[str] = []
+    for pair_key, entities in sorted(duplicates.items()):
+        left, right = pair_key.split(":", 1)
+        section = f"{left}/{right}: {', '.join(entities)}"
+        sections.append(section)
+    return "; ".join(sections)
+
+
+def _zone_sensor_sources(telemetry: List[Dict[str, Any]], zone: Dict[str, Any]) -> Set[str]:
+    level = str(zone.get("level") or "").strip()
+    rooms = {
+        str(room).strip().lower()
+        for room in (zone.get("rooms") or [])
+        if str(room).strip()
+    }
+    sources: Set[str] = set()
+    for item in telemetry:
+        sensor_type = str(item.get("sensor_type") or "").strip().lower()
+        if sensor_type not in _TRACKED_SENSOR_TYPES:
+            continue
+
+        entity_id = str(item.get("entity_id") or "").strip()
+        if not entity_id:
+            continue
+
+        if level and str(item.get("level") or "").strip() != level:
+            continue
+
+        room = str(item.get("room") or "").strip().lower()
+        if rooms and room not in rooms:
+            continue
+
+        sources.add(entity_id)
+    return sources

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "domain": "humidity_intelligence",
   "name": "Humidity Intelligence",
   "icon": "mdi:water-percent",
-  "version": "0.3.6",
+  "version": "2.0.1",
   "documentation": "https://github.com/senyo888/humidity-intelligence",
   "issue_tracker": "https://github.com/senyo888/humidity-intelligence/issues",
   "config_flow": true,

--- a/sensor.py
+++ b/sensor.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from homeassistant.core import HomeAssistant
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.event import async_track_state_change_event
@@ -14,6 +15,9 @@ from .const import DOMAIN
 from .sensors.core import build_entities
 from .sensors.slope import build_slope_entities
 from homeassistant.helpers.device_registry import DeviceInfo
+from .helpers.zone_validation import detect_zone_mapping_duplicates, summarize_zone_mapping_duplicates
+
+_LOGGER = logging.getLogger(__name__)
 
 
 TIMER_KEYS = [
@@ -26,10 +30,16 @@ TIMER_KEYS = [
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities) -> None:
+    alert_only_mode = bool(_entry_section(entry, "alert_only_mode", False))
     sensors, binary_sensors, sources = build_entities(hass, entry)
     slope_sensors, slope_sources, slope_map = build_slope_entities(hass, entry)
     diagnostics = HIDiagnosticsSensor(hass, entry.entry_id)
-    timer_sensors = [HITimerSensor(entry.entry_id, key) for key in TIMER_KEYS]
+    timer_sensors = [] if alert_only_mode else [HITimerSensor(entry.entry_id, key) for key in TIMER_KEYS]
+    if alert_only_mode:
+        _LOGGER.info(
+            "HI entry %s sensor platform running in alert-only mode; timer control entities are suppressed.",
+            entry.entry_id,
+        )
     async_add_entities(sensors + slope_sensors + timer_sensors + [diagnostics], update_before_add=True)
 
     hass.data.setdefault(DOMAIN, {}).setdefault(entry.entry_id, {})
@@ -66,10 +76,14 @@ class HIDiagnosticsSensor(SensorEntity):
         data = self.hass.data.get(DOMAIN, {}).get(self.entry_id, {})
         config = data.get("config", {})
         telemetry = config.get("telemetry", []) if isinstance(config, dict) else []
+        zones = config.get("zones", {}) if isinstance(config, dict) else {}
         cards = data.get("cards") or {}
         entity_map = data.get("entity_map") or {}
         unresolved = data.get("unresolved_placeholders") or []
         unresolved_by_card = data.get("unresolved_placeholders_by_card") or {}
+        duplicates = detect_zone_mapping_duplicates(telemetry, zones if isinstance(zones, dict) else {})
+        duplicate_summary = summarize_zone_mapping_duplicates(duplicates)
+        self._attr_native_value = "warning" if duplicates else "ok"
         self._attr_extra_state_attributes = {
             "config": _sanitize_json(config),
             "options": _sanitize_json(data.get("options", {})),
@@ -77,6 +91,8 @@ class HIDiagnosticsSensor(SensorEntity):
             "cards": list(cards.keys()),
             "unresolved_placeholders": _sanitize_json(unresolved),
             "unresolved_placeholders_by_card": _sanitize_json(unresolved_by_card),
+            "zone_mapping_duplicates": _sanitize_json(duplicates),
+            "zone_mapping_duplicate_summary": duplicate_summary,
             "counts": {
                 "telemetry": len(telemetry),
                 "mapped_entities": len([v for v in entity_map.values() if v]),
@@ -164,3 +180,11 @@ def _sanitize_json(value):
     except Exception:
         pass
     return value
+
+
+def _entry_section(entry: ConfigEntry, key: str, default):
+    options = getattr(entry, "options", None) or {}
+    if key in options:
+        return options.get(key, default)
+    data = getattr(entry, "data", None) or {}
+    return data.get(key, default)

--- a/sensors/core.py
+++ b/sensors/core.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, Callable, Dict, List, Optional, Tuple
@@ -16,6 +17,10 @@ from homeassistant.components.binary_sensor import BinarySensorEntity
 from homeassistant.util import slugify
 
 from ..const import DOMAIN
+from ..helpers.parsing import format_temperature, hass_temperature_unit, parse_numeric, parse_temperature
+from ..helpers.zone_validation import detect_zone_mapping_duplicates, summarize_zone_mapping_duplicates
+
+_LOGGER = logging.getLogger(__name__)
 
 
 @dataclass
@@ -113,9 +118,11 @@ class _CoreComputations:
         self.hass = hass
         self.entry = entry
         self.telemetry = telemetry
+        self.zones: Dict[str, Dict[str, Any]] = _entry_section(entry, "zones", {})
         self.rooms: Dict[str, Dict[str, str]] = {}
         self.room_labels: Dict[str, str] = {}
         self.levels: Dict[str, Dict[str, List[str]]] = {}
+        self._zone_duplicate_signature: Tuple[str, ...] = tuple()
         self._index()
 
     def _index(self) -> None:
@@ -269,6 +276,12 @@ class _CoreComputations:
             self._compute_worst_mould_risk,
             icon="mdi:biohazard",
         ))
+        sensors.append(make(
+            "HI Zone Mapping Duplicates",
+            "zone_mapping_duplicates",
+            self._compute_zone_mapping_duplicates,
+            icon="mdi:alert-outline",
+        ))
 
         for room in sorted(self.rooms.keys(), key=lambda r: r.lower()):
             if "humidity" not in self.rooms.get(room, {}):
@@ -387,7 +400,12 @@ class _CoreComputations:
 
     def _compute_house_avg_temperature(self) -> Tuple[Optional[float], Dict[str, Any]]:
         values = self._collect_values("temperature")
-        return _avg(values), {}
+        avg_c = _avg(values)
+        display_unit = hass_temperature_unit(self.hass)
+        return avg_c, {
+            "display_value": format_temperature(avg_c, display_unit),
+            "display_unit": display_unit,
+        }
 
     def _compute_level_avg_humidity(self, level: str) -> Tuple[Optional[float], Dict[str, Any]]:
         values = self._collect_values("humidity", level)
@@ -395,7 +413,12 @@ class _CoreComputations:
 
     def _compute_level_avg_temperature(self, level: str) -> Tuple[Optional[float], Dict[str, Any]]:
         values = self._collect_values("temperature", level)
-        return _avg(values), {}
+        avg_c = _avg(values)
+        display_unit = hass_temperature_unit(self.hass)
+        return avg_c, {
+            "display_value": format_temperature(avg_c, display_unit),
+            "display_unit": display_unit,
+        }
 
     def _compute_target_low(self) -> Tuple[int, Dict[str, Any]]:
         month = datetime.now().month
@@ -532,6 +555,32 @@ class _CoreComputations:
         _, attrs = self._compute_worst_mould()
         return attrs.get("risk", "Unknown"), {}
 
+    def _compute_zone_mapping_duplicates(self) -> Tuple[str, Dict[str, Any]]:
+        duplicates = detect_zone_mapping_duplicates(
+            self.telemetry,
+            self.zones if isinstance(self.zones, dict) else {},
+        )
+        duplicate_entities = sorted({entity for values in duplicates.values() for entity in values})
+        signature = tuple(duplicate_entities)
+        if duplicate_entities and signature != self._zone_duplicate_signature:
+            _LOGGER.warning(
+                "Zone mapping duplicates detected for entry %s: %s",
+                self.entry.entry_id,
+                summarize_zone_mapping_duplicates(duplicates),
+            )
+        self._zone_duplicate_signature = signature
+        if duplicate_entities:
+            return "detected", {
+                "message": "Zone mapping duplicates detected",
+                "duplicates": duplicates,
+                "duplicate_entities": duplicate_entities,
+            }
+        return "clear", {
+            "message": "No zone mapping duplicates detected",
+            "duplicates": {},
+            "duplicate_entities": [],
+        }
+
     def _compute_condensation_danger(self) -> Tuple[bool, Dict[str, Any]]:
         state, attrs = self._compute_worst_condensation()
         return attrs.get("risk") == "Danger", {"worst_room": state}
@@ -561,17 +610,67 @@ class _CoreComputations:
             for lvl in self.levels.values():
                 entity_ids.extend(lvl.get(sensor_type, []))
         values: List[float] = []
+        exclusions: List[Tuple[str, str]] = []
+        expected_unit: Optional[str] = None
         for entity_id in entity_ids:
-            val = _get_float(self.hass, entity_id)
-            if val is not None:
-                values.append(val)
+            state = self.hass.states.get(entity_id) if entity_id else None
+            if state is None:
+                exclusions.append((entity_id, "missing"))
+                continue
+
+            raw_state = str(state.state).strip()
+            lowered = raw_state.lower()
+            if lowered == "unknown":
+                exclusions.append((entity_id, "unknown"))
+                continue
+            if lowered == "unavailable":
+                exclusions.append((entity_id, "unavailable"))
+                continue
+
+            if sensor_type == "temperature":
+                temp_c, reason = parse_temperature(
+                    state.state,
+                    state.attributes.get("unit_of_measurement"),
+                    hass_temperature_unit(self.hass),
+                )
+                if temp_c is None:
+                    exclusions.append((entity_id, reason or "non_numeric"))
+                    continue
+                values.append(temp_c)
+                continue
+
+            val = parse_numeric(state.state)
+            if val is None:
+                exclusions.append((entity_id, "non_numeric"))
+                continue
+
+            normalized_unit = _normalize_sensor_unit(sensor_type, state.attributes.get("unit_of_measurement"))
+            if normalized_unit is not None:
+                if expected_unit is None:
+                    expected_unit = normalized_unit
+                elif normalized_unit != expected_unit:
+                    exclusions.append((entity_id, "unit_mismatch"))
+                    continue
+
+            values.append(val)
+
+        if exclusions:
+            scope = f"level={level}" if level else "house"
+            excluded_summary = ", ".join(f"{entity}:{reason}" for entity, reason in exclusions)
+            _LOGGER.debug(
+                "Excluded %s telemetry values for %s (%s): %s",
+                sensor_type,
+                self.entry.entry_id,
+                scope,
+                excluded_summary,
+            )
         return values
 
     def _room_metrics(self) -> List[_RoomMetrics]:
         metrics: List[_RoomMetrics] = []
         for room, sensors in self.rooms.items():
             rh = _get_float(self.hass, sensors.get("humidity"))
-            temp = _get_float(self.hass, sensors.get("temperature"))
+            temp = _get_temperature_c(self.hass, sensors.get("temperature"))
             if rh is None or temp is None:
                 cond = "Unknown"
                 mould = "Unknown"
@@ -631,12 +730,29 @@ def _get_float(hass: HomeAssistant, entity_id: Optional[str]) -> Optional[float]
     if not entity_id:
         return None
     state = hass.states.get(entity_id)
-    if state is None or state.state in ("unknown", "unavailable"):
+    if state is None:
         return None
-    try:
-        return float(state.state)
-    except ValueError:
+    raw_state = str(state.state).strip()
+    if raw_state.lower() in ("unknown", "unavailable"):
         return None
+    return parse_numeric(raw_state)
+
+
+def _get_temperature_c(hass: HomeAssistant, entity_id: Optional[str]) -> Optional[float]:
+    if not entity_id:
+        return None
+    state = hass.states.get(entity_id)
+    if state is None:
+        return None
+    raw_state = str(state.state).strip()
+    if raw_state.lower() in ("unknown", "unavailable"):
+        return None
+    value_c, _reason = parse_temperature(
+        state.state,
+        state.attributes.get("unit_of_measurement"),
+        hass_temperature_unit(hass),
+    )
+    return value_c
 
 
 def _avg(values: List[float]) -> Optional[float]:
@@ -691,6 +807,27 @@ def _mould_risk(rh: Optional[float], spread: Optional[float]) -> str:
 
 def _slugify_room(room: str) -> str:
     return slugify(room) if room else "room"
+
+
+_UNIT_ALIASES: Dict[str, Dict[str, str]] = {
+    "humidity": {"%": "%", "percent": "%", "rh": "%", "%rh": "%"},
+    "pm25": {"ug/m3": "ug/m3", "ug/m^3": "ug/m3", "μg/m3": "ug/m3", "µg/m3": "ug/m3"},
+    "voc": {"ppb": "ppb", "ppm": "ppm"},
+    "co2": {"ppm": "ppm"},
+    "co": {"ppm": "ppm"},
+}
+
+
+def _normalize_sensor_unit(sensor_type: str, unit: Any) -> Optional[str]:
+    if unit in (None, ""):
+        return None
+    aliases = _UNIT_ALIASES.get(sensor_type)
+    if aliases is None:
+        return None
+    normalized = str(unit).strip().lower().replace(" ", "")
+    normalized = normalized.replace("³", "3")
+    normalized = normalized.replace("μ", "u").replace("µ", "u")
+    return aliases.get(normalized, normalized)
 
 
 def _entry_section(entry: ConfigEntry, key: str, default: Any) -> Any:

--- a/sensors/slope.py
+++ b/sensors/slope.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections import deque
 from dataclasses import dataclass
 from datetime import datetime, timedelta
+import logging
 from typing import Any, Deque, Dict, List, Optional, Tuple
 import re
 
@@ -16,7 +17,9 @@ from homeassistant.components.sensor import SensorEntity, SensorStateClass
 from homeassistant.util import slugify
 
 from ..const import DOMAIN, SLOPE_MODE_CALCULATED, SLOPE_MODE_PROVIDED
+from ..helpers.parsing import hass_temperature_unit, parse_temperature
 
+_LOGGER = logging.getLogger(__name__)
 
 WINDOW = timedelta(hours=1)
 SAMPLE_INTERVAL = timedelta(minutes=5)
@@ -141,11 +144,18 @@ def build_slope_entities(hass: HomeAssistant, entry: ConfigEntry) -> Tuple[List[
 
     def _record_state(entity_id: str) -> bool:
         state = hass.states.get(entity_id)
-        if state is None or state.state in ("unknown", "unavailable"):
+        if state is None:
             return False
-        try:
-            value = float(state.state)
-        except ValueError:
+        raw_state = str(state.state).strip().lower()
+        if raw_state in ("unknown", "unavailable"):
+            return False
+        value, reason = parse_temperature(
+            state.state,
+            state.attributes.get("unit_of_measurement"),
+            hass_temperature_unit(hass),
+        )
+        if value is None:
+            _LOGGER.debug("Skipping slope sample for %s due to %s", entity_id, reason or "non_numeric")
             return False
         tracker.record(entity_id, value)
         return True

--- a/services.py
+++ b/services.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import re
 import tempfile
 from datetime import timedelta
 from typing import List, Optional, Tuple
@@ -30,38 +31,99 @@ SERVICE_PURGE_FILES = "purge_files"
 SERVICE_PAUSE_CONTROL = "pause_control"
 SERVICE_RESUME_CONTROL = "resume_control"
 
+_ALLOWED_LAYOUTS = {"v2_mobile", "v2_tablet", "v1_mobile", "view_cards_button"}
+_SAFE_FILENAME_RE = re.compile(r"^[A-Za-z0-9._-]{1,128}$")
+_SAFE_DASHBOARD_PATH_RE = re.compile(r"^[a-z0-9_-]{1,64}$")
+_SENSITIVE_ATTR_EXACT = {
+    "access_token",
+    "token",
+    "refresh_token",
+    "password",
+    "api_key",
+    "authorization",
+    "latitude",
+    "longitude",
+    "gps_accuracy",
+}
+_SENSITIVE_ATTR_PARTIAL = (
+    "token",
+    "secret",
+    "password",
+    "api_key",
+    "apikey",
+    "access_key",
+    "authorization",
+    "bearer",
+    "latitude",
+    "longitude",
+    "gps_",
+)
+
+
+def _validate_layout(value: str) -> str:
+    text = str(value).strip()
+    if text not in _ALLOWED_LAYOUTS:
+        raise vol.Invalid(
+            f"Unsupported layout '{text}'. Allowed: {', '.join(sorted(_ALLOWED_LAYOUTS))}"
+        )
+    return text
+
+
+def _validate_safe_filename(value: str) -> str:
+    text = str(value).strip()
+    if not text:
+        raise vol.Invalid("Filename cannot be empty")
+    if "/" in text or "\\" in text or ".." in text:
+        raise vol.Invalid("Filename must not include directory traversal or separators")
+    if not _SAFE_FILENAME_RE.fullmatch(text):
+        raise vol.Invalid("Filename contains invalid characters")
+    return text
+
+
+def _validate_dashboard_url_path(value: str) -> str:
+    text = str(value).strip().lower()
+    if not _SAFE_DASHBOARD_PATH_RE.fullmatch(text):
+        raise vol.Invalid(
+            "Dashboard URL path must use only lowercase letters, numbers, '_' or '-'"
+        )
+    return text
+
+
 SERVICE_FLASH_SCHEMA = vol.Schema({
     vol.Optional("power_entity"): cv.entity_id,
-    vol.Required("lights"): cv.entity_ids,
+    vol.Optional("lights", default=[]): cv.entity_ids,
     vol.Optional("color", default=(255, 0, 0)): vol.All(cv.ensure_list, [vol.Coerce(int)]),
-    vol.Optional("duration", default=10): vol.Coerce(int),
-    vol.Optional("flash_count", default=None): vol.Any(None, vol.Coerce(int)),
+    vol.Optional("duration", default=10): vol.All(vol.Coerce(int), vol.Range(min=1, max=300)),
+    vol.Optional("flash_count", default=None): vol.Any(
+        None,
+        vol.All(vol.Coerce(int), vol.Range(min=1, max=240)),
+    ),
 })
 SERVICE_REFRESH_SCHEMA = vol.Schema({
     vol.Optional("entry_id"): cv.string,
 })
 SERVICE_DUMP_SCHEMA = vol.Schema({
     vol.Optional("entry_id"): cv.string,
-    vol.Optional("filename", default="humidity_intelligence_diagnostics.json"): cv.string,
+    vol.Optional("filename", default="humidity_intelligence_diagnostics.json"): _validate_safe_filename,
 })
 SERVICE_SELF_CHECK_SCHEMA = vol.Schema({
     vol.Optional("entry_id"): cv.string,
 })
 SERVICE_DUMP_CARDS_SCHEMA = vol.Schema({
     vol.Optional("entry_id"): cv.string,
-    vol.Optional("filename"): cv.string,
-    vol.Optional("layout"): cv.string,
+    vol.Optional("filename"): _validate_safe_filename,
+    vol.Optional("layout"): _validate_layout,
 })
 SERVICE_CREATE_DASHBOARD_SCHEMA = vol.Schema({
     vol.Optional("entry_id"): cv.string,
-    vol.Optional("layout", default="v2_mobile"): cv.string,
+    vol.Optional("layout", default="v2_mobile"): _validate_layout,
     vol.Optional("title", default="Humidity Intelligence"): cv.string,
-    vol.Optional("url_path", default="humidity-intelligence"): cv.string,
+    vol.Optional("url_path", default="humidity-intelligence"): _validate_dashboard_url_path,
 })
 SERVICE_VIEW_CARDS_SCHEMA = vol.Schema({
     vol.Optional("entry_id"): cv.string,
-    vol.Optional("filename"): cv.string,
-    vol.Optional("layout"): cv.string,
+    vol.Optional("filename"): _validate_safe_filename,
+    vol.Optional("layout"): _validate_layout,
 })
 SERVICE_PURGE_FILES_SCHEMA = vol.Schema({
     vol.Optional("entry_id"): cv.string,
@@ -87,7 +149,7 @@ async def async_register_services(hass: HomeAssistant) -> None:
         color = tuple(color_list[:3]) if len(color_list) >= 3 else (255, 0, 0)
 
         if not lights:
-            _LOGGER.warning("No lights provided to flash")
+            _LOGGER.debug("No lights provided to flash_lights; skipping light flash.")
             return
 
         if power_entity:
@@ -151,7 +213,7 @@ async def async_register_services(hass: HomeAssistant) -> None:
                         continue
                     state_dump[ent] = {
                         "state": state.state,
-                        "attributes": _to_jsonable(dict(state.attributes)),
+                        "attributes": _redact_sensitive_attributes(dict(state.attributes)),
                     }
                 payload[entry.entry_id] = {
                     "config": _to_jsonable(data.get("config", {})),
@@ -442,6 +504,18 @@ def _to_jsonable(value):
         except Exception:
             pass
     return str(value)
+
+
+def _redact_sensitive_attributes(attributes: dict) -> dict:
+    redacted = {}
+    for key, value in attributes.items():
+        key_text = str(key)
+        key_norm = key_text.lower()
+        if key_norm in _SENSITIVE_ATTR_EXACT or any(part in key_norm for part in _SENSITIVE_ATTR_PARTIAL):
+            redacted[key_text] = "[REDACTED]"
+        else:
+            redacted[key_text] = _to_jsonable(value)
+    return redacted
 
 
 async def _dump_cards_to_file(

--- a/services.yaml
+++ b/services.yaml
@@ -10,8 +10,8 @@ flash_lights:
           domain: [switch, light]
     lights:
       name: Lights to flash
-      description: One or more lights to flash
-      required: true
+      description: Optional lights to flash
+      required: false
       selector:
         entity:
           domain: light
@@ -23,21 +23,21 @@ flash_lights:
         color_rgb: {}
     duration:
       name: Duration in seconds
-      description: Total flash duration
+      description: Total flash duration (1-300s)
       selector:
         number:
           min: 1
-          max: 120
+          max: 300
           step: 1
           mode: slider
           unit_of_measurement: s
     flash_count:
       name: Number of flashes
-      description: Override flash count (optional)
+      description: Override flash count (optional, 1-240)
       selector:
         number:
           min: 1
-          max: 200
+          max: 240
           step: 1
           mode: slider
 refresh_ui:
@@ -60,7 +60,7 @@ dump_diagnostics:
         text: {}
     filename:
       name: Filename
-      description: Output filename in the HA config folder
+      description: Output filename in the HA config folder (basename only, no slashes)
       selector:
         text: {}
 self_check:
@@ -83,7 +83,7 @@ dump_cards:
         text: {}
     filename:
       name: Filename
-      description: Optional base filename (defaults to humidity_intelligence_cards)
+      description: Optional base filename (defaults to humidity_intelligence_cards; basename only)
       selector:
         text: {}
     layout:
@@ -115,7 +115,7 @@ create_dashboard:
         text: {}
     url_path:
       name: URL path
-      description: Sidebar URL path (no slashes)
+      description: Sidebar URL path (lowercase letters/numbers/_/- only)
       selector:
         text: {}
 view_cards:
@@ -129,7 +129,7 @@ view_cards:
         text: {}
     filename:
       name: Filename
-      description: Optional base filename (defaults to humidity_intelligence_cards)
+      description: Optional base filename (defaults to humidity_intelligence_cards; basename only)
       selector:
         text: {}
     layout:

--- a/strings.json
+++ b/strings.json
@@ -18,6 +18,7 @@
           "end_time": "End time",
           "outside_action": "Outside window action",
           "engine_interval_minutes": "Control loop interval",
+          "alert_only_mode": "Alert-only mode (monitor + alerts only)",
           "enable_presence_gate": "Enable presence gate",
           "presence_entities": "Presence entities (any helper/entity)"
         }
@@ -216,12 +217,20 @@
       "alert_add": {
         "title": "Add Alert",
         "description": "Configure a high-priority alert automation.\n\nCondensation and mould danger entities are provided by Humidity Intelligence. You do not need custom binary sensors for those triggers, but you may optionally provide one for the Custom trigger type.",
+        "errors": {
+          "alert_save_failed": "Failed to save alert configuration. Check logs and try again.",
+          "custom_trigger_required": "A custom binary sensor is required for Custom trigger type.",
+          "room_unknown": "Selected room is not in configured telemetry.",
+          "room_missing_humidity": "Selected room has no humidity telemetry for room-scoped humidity danger.",
+          "room_missing_temp_humidity": "Selected room needs both humidity and temperature telemetry for this room-scoped trigger."
+        },
         "data": {
           "enabled": "Enable alert",
           "trigger_type": "Trigger type",
           "custom_trigger": "Custom binary sensor",
           "threshold": "Threshold",
-          "lights": "Lights to flash",
+          "room": "Room scope (optional)",
+          "lights": "Lights to flash (optional)",
           "outputs": "CO output devices (optional)",
           "power_entity": "Power entity (optional)",
           "flash_mode": "Flash mode",
@@ -262,6 +271,7 @@
           "end_time": "End time",
           "outside_action": "Outside window action",
           "engine_interval_minutes": "Control loop interval",
+          "alert_only_mode": "Alert-only mode (monitor + alerts only)",
           "enable_presence_gate": "Enable presence gate",
           "presence_entities": "Presence/alarm entities"
         }
@@ -309,8 +319,12 @@
       "options_telemetry_edit": {
         "title": "Edit Telemetry Sensor",
         "description": "Editing sensor {sensor_position} of {sensor_total}.\n\n{selected_sensor}",
+        "errors": {
+          "duplicate_entity": "This sensor has already been added."
+        },
         "data": {
           "entity_id": "Sensor entity",
+          "sensor_type": "Sensor type",
           "friendly_name": "Friendly name (display only)",
           "level": "Level",
           "room": "Room"
@@ -343,7 +357,7 @@
       },
       "options_humidifiers": {
         "title": "Humidifier Options",
-        "description": "Select a humidifier lane to edit.\n\nConfigured humidifier lanes:\n{configured_humidifiers}",
+        "description": "Select a humidifier lane to add, edit, or remove.\n\nConfigured humidifier lanes:\n{configured_humidifiers}",
         "data": {
           "action": "Humidifier lane"
         }
@@ -352,6 +366,7 @@
         "title": "Edit Humidifier Lane",
         "description": "Editing {level_label}.",
         "data": {
+          "remove_lane": "Remove this humidifier lane",
           "enabled": "Enable humidifier lane",
           "band_adjust": "Target band adjustment",
           "outputs": "Humidifier outputs"
@@ -359,7 +374,7 @@
       },
       "options_aq": {
         "title": "Air Quality Options",
-        "description": "Select an AQ lane to edit.\n\nConfigured AQ lanes:\n{configured_aq}",
+        "description": "Select an AQ lane to add, edit, or remove.\n\nConfigured AQ lanes:\n{configured_aq}",
         "data": {
           "action": "AQ lane"
         }
@@ -368,6 +383,7 @@
         "title": "Edit Air Quality Lane",
         "description": "Editing {level_label}.",
         "data": {
+          "remove_lane": "Remove this AQ lane",
           "enabled": "Enable AQ lane",
           "triggers": "AQ triggers",
           "outputs": "AQ output devices",
@@ -387,15 +403,46 @@
           "action": "Alert to edit"
         }
       },
-      "options_alert_edit": {
-        "title": "Edit Alert",
-        "description": "Editing {alert_label}.",
+      "options_alert_add": {
+        "title": "Add Alert",
+        "description": "Configure a new high-priority alert automation.",
+        "errors": {
+          "alert_save_failed": "Failed to save alert configuration. Check logs and try again.",
+          "custom_trigger_required": "A custom binary sensor is required for Custom trigger type.",
+          "room_unknown": "Selected room is not in configured telemetry.",
+          "room_missing_humidity": "Selected room has no humidity telemetry for room-scoped humidity danger.",
+          "room_missing_temp_humidity": "Selected room needs both humidity and temperature telemetry for this room-scoped trigger."
+        },
         "data": {
           "enabled": "Enable alert",
           "trigger_type": "Trigger type",
           "custom_trigger": "Custom trigger entity (optional)",
           "threshold": "Threshold",
-          "lights": "Target lights",
+          "room": "Room scope (optional)",
+          "lights": "Target lights (optional)",
+          "outputs": "CO output devices (optional)",
+          "power_entity": "Power entity (optional)",
+          "flash_mode": "Flash mode",
+          "duration": "Flash duration"
+        }
+      },
+      "options_alert_edit": {
+        "title": "Edit Alert",
+        "description": "Editing {alert_label}.",
+        "errors": {
+          "alert_save_failed": "Failed to save alert configuration. Check logs and try again.",
+          "custom_trigger_required": "A custom binary sensor is required for Custom trigger type.",
+          "room_unknown": "Selected room is not in configured telemetry.",
+          "room_missing_humidity": "Selected room has no humidity telemetry for room-scoped humidity danger.",
+          "room_missing_temp_humidity": "Selected room needs both humidity and temperature telemetry for this room-scoped trigger."
+        },
+        "data": {
+          "enabled": "Enable alert",
+          "trigger_type": "Trigger type",
+          "custom_trigger": "Custom trigger entity (optional)",
+          "threshold": "Threshold",
+          "room": "Room scope (optional)",
+          "lights": "Target lights (optional)",
           "outputs": "CO output devices (optional)",
           "power_entity": "Power entity (optional)",
           "flash_mode": "Flash mode",

--- a/switch.py
+++ b/switch.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from typing import Any, Dict, List, Tuple
 
 from homeassistant.core import HomeAssistant
@@ -12,6 +13,8 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.components.switch import SwitchEntity
 
 from .const import ALERT_TRIGGER_DEFS, DOMAIN, MAX_ALERTS, UI_DROPDOWN_AUTO_CLOSE_SECONDS
+
+_LOGGER = logging.getLogger(__name__)
 
 
 BASE_SWITCH_KEYS = [
@@ -27,6 +30,10 @@ BASE_SWITCH_KEYS = [
     "air_upstairs_humidifier_active",
     "humidity_constellation_expanded",
     "toggle",
+]
+
+ALERT_ONLY_BASE_SWITCH_KEYS = [
+    "air_co_emergency_active",
 ]
 
 DEFAULT_ON = {"air_control_enabled"}
@@ -110,8 +117,15 @@ class HIInputSwitch(SwitchEntity, RestoreEntity):
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities) -> None:
     entities: List[HIInputSwitch] = []
-    for key in BASE_SWITCH_KEYS:
+    alert_only_mode = bool(_entry_section(entry, "alert_only_mode", False))
+    base_keys = ALERT_ONLY_BASE_SWITCH_KEYS if alert_only_mode else BASE_SWITCH_KEYS
+    for key in base_keys:
         entities.append(HIInputSwitch(entry.entry_id, key))
+    if alert_only_mode:
+        _LOGGER.info(
+            "HI entry %s switch platform running in alert-only mode; control switches are suppressed.",
+            entry.entry_id,
+        )
     alert_switches: Dict[int, HIInputSwitch] = {}
     for idx, key, name, attrs in _alert_switch_definitions(entry):
         entity = HIInputSwitch(entry.entry_id, key, name=name, attrs=attrs)
@@ -131,6 +145,14 @@ def _resolved_alerts(entry: ConfigEntry) -> List[Dict[str, Any]]:
     if entry.options and "alerts" in entry.options:
         return list(entry.options.get("alerts", []))
     return list(entry.data.get("alerts", []))
+
+
+def _entry_section(entry: ConfigEntry, key: str, default: Any) -> Any:
+    options = getattr(entry, "options", None) or {}
+    if key in options:
+        return options.get(key, default)
+    data = getattr(entry, "data", None) or {}
+    return data.get(key, default)
 
 
 def _alert_switch_definitions(entry: ConfigEntry) -> List[Tuple[int, str, str, Dict[str, Any]]]:

--- a/tests/test_runtime_card_sanity.py
+++ b/tests/test_runtime_card_sanity.py
@@ -20,6 +20,7 @@ def _install_homeassistant_stubs() -> None:
     ha = types.ModuleType("homeassistant")
     core = types.ModuleType("homeassistant.core")
     config_entries = types.ModuleType("homeassistant.config_entries")
+    const = types.ModuleType("homeassistant.const")
     helpers = types.ModuleType("homeassistant.helpers")
     event = types.ModuleType("homeassistant.helpers.event")
     entity_registry = types.ModuleType("homeassistant.helpers.entity_registry")
@@ -30,6 +31,10 @@ def _install_homeassistant_stubs() -> None:
     class ConfigEntry:
         pass
 
+    class UnitOfTemperature:
+        CELSIUS = "°C"
+        FAHRENHEIT = "°F"
+
     def async_track_state_change_event(*args, **kwargs):
         return lambda: None
 
@@ -38,6 +43,8 @@ def _install_homeassistant_stubs() -> None:
 
     core.HomeAssistant = HomeAssistant
     config_entries.ConfigEntry = ConfigEntry
+    const.UnitOfTemperature = UnitOfTemperature
+    const.PERCENTAGE = "%"
     event.async_track_state_change_event = async_track_state_change_event
     event.async_track_time_interval = async_track_time_interval
     entity_registry.async_get = lambda hass: None
@@ -45,6 +52,7 @@ def _install_homeassistant_stubs() -> None:
     sys.modules["homeassistant"] = ha
     sys.modules["homeassistant.core"] = core
     sys.modules["homeassistant.config_entries"] = config_entries
+    sys.modules["homeassistant.const"] = const
     sys.modules["homeassistant.helpers"] = helpers
     sys.modules["homeassistant.helpers.event"] = event
     sys.modules["homeassistant.helpers.entity_registry"] = entity_registry
@@ -56,7 +64,7 @@ def _install_package_scaffold() -> None:
     pkg.__path__ = [str(ROOT)]
     sys.modules[PKG] = pkg
 
-    for sub in ("automations", "ui"):
+    for sub in ("automations", "ui", "helpers"):
         mod = types.ModuleType(f"{PKG}.{sub}")
         mod.__path__ = [str(ROOT / sub)]
         sys.modules[f"{PKG}.{sub}"] = mod
@@ -409,6 +417,123 @@ async def _run_runtime_assertions(engine_mod) -> None:
     alert_reason = hass.data["humidity_intelligence"][ENTRY_ID].get("runtime_reason", "")
     assert "Alert response is active" in alert_reason
     assert "All other lanes are paused" in alert_reason
+
+    # Room-scoped humidity danger alert should only trigger for the selected room.
+    entry_room_alert_data = _base_entry_data()
+    entry_room_alert_data["zones"]["zone1"]["enabled"] = False
+    entry_room_alert_data["zones"]["zone2"]["enabled"] = False
+    entry_room_alert_data["aq"] = {}
+    entry_room_alert_data["humidifiers"] = {}
+    entry_room_alert_data["alerts"] = [
+        {
+            "enabled": True,
+            "trigger_type": "humidity_danger",
+            "threshold": 70,
+            "room": "Kitchen",
+            "lights": ["light.alert"],
+            "duration": 10,
+        }
+    ]
+    entry_room_alert = SimpleNamespace(entry_id=ENTRY_ID, data=entry_room_alert_data, options={})
+    hass_room_alert = _FakeHass(
+        entry_room_alert,
+        {
+            "sensor.kitchen_h": _FakeState(82),
+            "sensor.hall_h": _FakeState(45),
+            "sensor.bed_h": _FakeState(50),
+            "sensor.kitchen_t": _FakeState(23),
+            "sensor.hall_t": _FakeState(22),
+            "sensor.bed_t": _FakeState(21),
+            "sensor.l1_iaq": _FakeState(85),
+            "sensor.co_val": _FakeState(4),
+        },
+    )
+    engine_room_alert = HIAutomationEngine(hass_room_alert, entry_room_alert)
+    await engine_room_alert._evaluate()
+    assert hass_room_alert.data["humidity_intelligence"][ENTRY_ID].get("runtime_mode") == "alert"
+    room_alert_reason = hass_room_alert.data["humidity_intelligence"][ENTRY_ID].get("runtime_reason", "")
+    assert (
+        "Humidity Danger @ 70 in Kitchen" in room_alert_reason
+        or "Humidity Danger @ 70.0 in Kitchen" in room_alert_reason
+    )
+
+    # Alerts without target lights should still activate runtime alert mode,
+    # but skip light flash service calls cleanly.
+    entry_room_alert_no_lights_data = _base_entry_data()
+    entry_room_alert_no_lights_data["zones"]["zone1"]["enabled"] = False
+    entry_room_alert_no_lights_data["zones"]["zone2"]["enabled"] = False
+    entry_room_alert_no_lights_data["aq"] = {}
+    entry_room_alert_no_lights_data["humidifiers"] = {}
+    entry_room_alert_no_lights_data["alerts"] = [
+        {
+            "enabled": True,
+            "trigger_type": "humidity_danger",
+            "threshold": 70,
+            "room": "Kitchen",
+            "duration": 10,
+        }
+    ]
+    entry_room_alert_no_lights = SimpleNamespace(
+        entry_id=ENTRY_ID,
+        data=entry_room_alert_no_lights_data,
+        options={},
+    )
+    hass_room_alert_no_lights = _FakeHass(
+        entry_room_alert_no_lights,
+        {
+            "sensor.kitchen_h": _FakeState(82),
+            "sensor.hall_h": _FakeState(45),
+            "sensor.bed_h": _FakeState(50),
+            "sensor.kitchen_t": _FakeState(23),
+            "sensor.hall_t": _FakeState(22),
+            "sensor.bed_t": _FakeState(21),
+            "sensor.l1_iaq": _FakeState(85),
+            "sensor.co_val": _FakeState(4),
+        },
+    )
+    engine_room_alert_no_lights = HIAutomationEngine(
+        hass_room_alert_no_lights,
+        entry_room_alert_no_lights,
+    )
+    await engine_room_alert_no_lights._evaluate()
+    assert hass_room_alert_no_lights.data["humidity_intelligence"][ENTRY_ID].get("runtime_mode") == "alert"
+    assert not any(
+        domain == "humidity_intelligence" and service == "flash_lights"
+        for domain, service, *_ in hass_room_alert_no_lights.services.calls
+    )
+
+    entry_room_alert_miss_data = _base_entry_data()
+    entry_room_alert_miss_data["zones"]["zone1"]["enabled"] = False
+    entry_room_alert_miss_data["zones"]["zone2"]["enabled"] = False
+    entry_room_alert_miss_data["aq"] = {}
+    entry_room_alert_miss_data["humidifiers"] = {}
+    entry_room_alert_miss_data["alerts"] = [
+        {
+            "enabled": True,
+            "trigger_type": "humidity_danger",
+            "threshold": 70,
+            "room": "Hallway",
+            "lights": ["light.alert"],
+            "duration": 10,
+        }
+    ]
+    entry_room_alert_miss = SimpleNamespace(entry_id=ENTRY_ID, data=entry_room_alert_miss_data, options={})
+    hass_room_alert_miss = _FakeHass(
+        entry_room_alert_miss,
+        {
+            "sensor.kitchen_h": _FakeState(82),
+            "sensor.hall_h": _FakeState(45),
+            "sensor.bed_h": _FakeState(50),
+            "sensor.kitchen_t": _FakeState(23),
+            "sensor.hall_t": _FakeState(22),
+            "sensor.bed_t": _FakeState(21),
+            "sensor.l1_iaq": _FakeState(85),
+            "sensor.co_val": _FakeState(4),
+        },
+    )
+    engine_room_alert_miss = HIAutomationEngine(hass_room_alert_miss, entry_room_alert_miss)
+    await engine_room_alert_miss._evaluate()
+    assert hass_room_alert_miss.data["humidity_intelligence"][ENTRY_ID].get("runtime_mode") != "alert"
 
     # Zone label and fan-step enforcement: custom UI label should be surfaced,
     # and unsupported percentages should snap to the nearest supported level.
@@ -854,6 +979,89 @@ def _contains_v2_border_pill_sync_logic(yaml_text: str) -> bool:
     )
 
 
+def _has_empty_cards_block(yaml_text: str) -> bool:
+    lines = yaml_text.splitlines()
+    for idx, line in enumerate(lines):
+        if line.strip() != "cards:":
+            continue
+        indent = len(line) - len(line.lstrip(" \t"))
+        next_idx = idx + 1
+        while next_idx < len(lines) and not lines[next_idx].strip():
+            next_idx += 1
+        if next_idx >= len(lines):
+            return True
+        next_indent = len(lines[next_idx]) - len(lines[next_idx].lstrip(" \t"))
+        if next_indent <= indent:
+            return True
+    return False
+
+
+def _has_invalid_conditional_block(yaml_text: str) -> bool:
+    lines = yaml_text.splitlines()
+    for idx, line in enumerate(lines):
+        if line.strip() != "- type: conditional":
+            continue
+
+        base_indent = len(line) - len(line.lstrip(" \t"))
+        end = idx + 1
+        while end < len(lines):
+            nxt = lines[end]
+            if not nxt.strip():
+                end += 1
+                continue
+            nxt_indent = len(nxt) - len(nxt.lstrip(" \t"))
+            if nxt_indent <= base_indent and nxt.lstrip().startswith("- "):
+                break
+            end += 1
+
+        block = lines[idx:end]
+        top_level_indent = base_indent + 2
+        conditions_idx = None
+        card_idx = None
+        for rel, bline in enumerate(block[1:], start=1):
+            stripped = bline.lstrip(" \t")
+            indent = len(bline) - len(stripped)
+            if indent != top_level_indent:
+                continue
+            if stripped.startswith("conditions:") and conditions_idx is None:
+                conditions_idx = rel
+            if stripped.startswith("card:") and card_idx is None:
+                card_idx = rel
+
+        if conditions_idx is None or card_idx is None:
+            return True
+
+        conditions_indent = top_level_indent
+        has_condition_item = False
+        for rel in range(conditions_idx + 1, len(block)):
+            bline = block[rel]
+            if not bline.strip():
+                continue
+            indent = len(bline) - len(bline.lstrip(" \t"))
+            if indent <= conditions_indent:
+                break
+            if bline.lstrip(" \t").startswith("- "):
+                has_condition_item = True
+                break
+        if not has_condition_item:
+            return True
+
+        card_indent = top_level_indent
+        has_card_body = False
+        for rel in range(card_idx + 1, len(block)):
+            bline = block[rel]
+            if not bline.strip():
+                continue
+            indent = len(bline) - len(bline.lstrip(" \t"))
+            if indent <= card_indent:
+                break
+            has_card_body = True
+            break
+        if not has_card_body:
+            return True
+    return False
+
+
 async def _run_card_assertions(register_mod) -> None:
     sys.modules["homeassistant.helpers.entity_registry"].async_get = lambda hass: _FakeRegistry()
 
@@ -922,6 +1130,46 @@ async def _run_card_assertions(register_mod) -> None:
     assert "input_boolean.air_isolate_humidifier_outputs" not in cards.get("v2_mobile", "")
     assert "input_boolean.air_isolate_fan_outputs" not in cards.get("v2_tablet", "")
     assert "input_boolean.air_isolate_humidifier_outputs" not in cards.get("v2_tablet", "")
+    assert not _has_empty_cards_block(cards.get("v2_mobile", ""))
+    assert not _has_empty_cards_block(cards.get("v2_tablet", ""))
+    assert not _has_invalid_conditional_block(cards.get("v2_mobile", ""))
+    assert not _has_invalid_conditional_block(cards.get("v2_tablet", ""))
+
+
+async def _run_alert_only_card_assertions(register_mod) -> None:
+    sys.modules["homeassistant.helpers.entity_registry"].async_get = lambda hass: _FakeRegistry()
+
+    entry = SimpleNamespace(
+        entry_id=ENTRY_ID,
+        data={
+            "alert_only_mode": True,
+            "telemetry": [
+                {"entity_id": "sensor.kitchen_h", "sensor_type": "humidity", "level": "level1", "room": "Kitchen"},
+                {"entity_id": "sensor.kitchen_t", "sensor_type": "temperature", "level": "level1", "room": "Kitchen"},
+            ],
+            "zones": {},
+            "humidifiers": {},
+            "alerts": [],
+        },
+        options={},
+    )
+    hass = _FakeHass(entry, {})
+    hass.config_entries = _FakeConfigEntries(entry)
+
+    mapping = await register_mod.async_build_entity_mapping(hass, ENTRY_ID)
+    cards = await register_mod.async_register_cards(hass, ENTRY_ID, mapping)
+    mobile = cards.get("v2_mobile", "")
+    tablet = cards.get("v2_tablet", "")
+
+    assert "entity: input_boolean.air_control_enabled" not in mobile
+    assert "entity: timer.air_control_pause" not in mobile
+    assert "entity: input_boolean.air_control_output_expanded" not in mobile
+    assert "- entity: fan.kitchen_air" not in mobile
+    assert "- entity: humidifier.downstairs_humidifier" not in mobile
+    assert "Monitor + alerts only (no automation output controls configured)." in mobile
+    assert "Monitor + alerts only (no automation output controls configured)." in tablet
+    assert not _has_empty_cards_block(mobile)
+    assert not _has_invalid_conditional_block(mobile)
 
 
 def test_runtime_lane_order_and_service_simulation():
@@ -932,3 +1180,54 @@ def test_runtime_lane_order_and_service_simulation():
 def test_card_render_sanity_and_placeholder_resolution():
     _, register_mod = _load_target_modules()
     asyncio.run(_run_card_assertions(register_mod))
+
+
+def test_card_render_hides_controls_in_alert_only_mode():
+    _, register_mod = _load_target_modules()
+    asyncio.run(_run_alert_only_card_assertions(register_mod))
+
+
+def test_temperature_normalization_respects_source_units():
+    engine_mod, _ = _load_target_modules()
+    entry = SimpleNamespace(entry_id=ENTRY_ID, data={}, options={})
+    hass = _FakeHass(
+        entry,
+        {
+            "sensor.temp_f": _FakeState(68, {"unit_of_measurement": "°F"}),
+            "sensor.temp_c": _FakeState(20, {"unit_of_measurement": "°C"}),
+            "sensor.temp_no_unit": _FakeState(21),
+        },
+    )
+
+    from_f = engine_mod._get_float(hass, "sensor.temp_f", sensor_type="temperature")
+    from_c = engine_mod._get_float(hass, "sensor.temp_c", sensor_type="temperature")
+    from_missing_unit = engine_mod._get_float(hass, "sensor.temp_no_unit", sensor_type="temperature")
+
+    assert from_f is not None and abs(from_f - 20.0) < 0.05
+    assert from_c is not None and abs(from_c - 20.0) < 0.05
+    assert from_missing_unit is not None and abs(from_missing_unit - 21.0) < 0.05
+
+
+def test_level_average_ignores_unknown_unavailable_and_non_numeric_states():
+    engine_mod, _ = _load_target_modules()
+    entry_data = _base_entry_data()
+    entry_data["telemetry"].extend(
+        [
+            {"entity_id": "sensor.l1_iaq_unavailable", "sensor_type": "iaq", "level": "level1", "room": "Kitchen"},
+            {"entity_id": "sensor.l1_iaq_text", "sensor_type": "iaq", "level": "level1", "room": "Kitchen"},
+            {"entity_id": "sensor.l1_iaq_bad", "sensor_type": "iaq", "level": "level1", "room": "Kitchen"},
+        ]
+    )
+    entry = SimpleNamespace(entry_id=ENTRY_ID, data=entry_data, options={})
+    hass = _FakeHass(
+        entry,
+        {
+            "sensor.l1_iaq": _FakeState("unknown"),
+            "sensor.l1_iaq_unavailable": _FakeState("unavailable"),
+            "sensor.l1_iaq_text": _FakeState("57.2"),
+            "sensor.l1_iaq_bad": _FakeState("not_a_number"),
+        },
+    )
+
+    engine = engine_mod.HIAutomationEngine(hass, entry)
+    assert engine._level_avg("iaq", "level1") == 57.2

--- a/translations/en.json
+++ b/translations/en.json
@@ -18,6 +18,7 @@
           "end_time": "End time",
           "outside_action": "Outside window action",
           "engine_interval_minutes": "Control loop interval",
+          "alert_only_mode": "Alert-only mode (monitor + alerts only)",
           "enable_presence_gate": "Enable presence gate",
           "presence_entities": "Presence entities (any helper/entity)"
         }
@@ -216,12 +217,20 @@
       "alert_add": {
         "title": "Add Alert",
         "description": "Configure a high-priority alert automation.\n\nCondensation and mould danger entities are provided by Humidity Intelligence. You do not need custom binary sensors for those triggers, but you may optionally provide one for the Custom trigger type.",
+        "errors": {
+          "alert_save_failed": "Failed to save alert configuration. Check logs and try again.",
+          "custom_trigger_required": "A custom binary sensor is required for Custom trigger type.",
+          "room_unknown": "Selected room is not in configured telemetry.",
+          "room_missing_humidity": "Selected room has no humidity telemetry for room-scoped humidity danger.",
+          "room_missing_temp_humidity": "Selected room needs both humidity and temperature telemetry for this room-scoped trigger."
+        },
         "data": {
           "enabled": "Enable alert",
           "trigger_type": "Trigger type",
           "custom_trigger": "Custom binary sensor",
           "threshold": "Threshold",
-          "lights": "Lights to flash",
+          "room": "Room scope (optional)",
+          "lights": "Lights to flash (optional)",
           "outputs": "CO output devices (optional)",
           "power_entity": "Power entity (optional)",
           "flash_mode": "Flash mode",
@@ -262,6 +271,7 @@
           "end_time": "End time",
           "outside_action": "Outside window action",
           "engine_interval_minutes": "Control loop interval",
+          "alert_only_mode": "Alert-only mode (monitor + alerts only)",
           "enable_presence_gate": "Enable presence gate",
           "presence_entities": "Presence/alarm entities"
         }
@@ -309,8 +319,12 @@
       "options_telemetry_edit": {
         "title": "Edit Telemetry Sensor",
         "description": "Editing sensor {sensor_position} of {sensor_total}.\n\n{selected_sensor}",
+        "errors": {
+          "duplicate_entity": "This sensor has already been added."
+        },
         "data": {
           "entity_id": "Sensor entity",
+          "sensor_type": "Sensor type",
           "friendly_name": "Friendly name (display only)",
           "level": "Level",
           "room": "Room"
@@ -343,7 +357,7 @@
       },
       "options_humidifiers": {
         "title": "Humidifier Options",
-        "description": "Select a humidifier lane to edit.\n\nConfigured humidifier lanes:\n{configured_humidifiers}",
+        "description": "Select a humidifier lane to add, edit, or remove.\n\nConfigured humidifier lanes:\n{configured_humidifiers}",
         "data": {
           "action": "Humidifier lane"
         }
@@ -352,6 +366,7 @@
         "title": "Edit Humidifier Lane",
         "description": "Editing {level_label}.",
         "data": {
+          "remove_lane": "Remove this humidifier lane",
           "enabled": "Enable humidifier lane",
           "band_adjust": "Target band adjustment",
           "outputs": "Humidifier outputs"
@@ -359,7 +374,7 @@
       },
       "options_aq": {
         "title": "Air Quality Options",
-        "description": "Select an AQ lane to edit.\n\nConfigured AQ lanes:\n{configured_aq}",
+        "description": "Select an AQ lane to add, edit, or remove.\n\nConfigured AQ lanes:\n{configured_aq}",
         "data": {
           "action": "AQ lane"
         }
@@ -368,6 +383,7 @@
         "title": "Edit Air Quality Lane",
         "description": "Editing {level_label}.",
         "data": {
+          "remove_lane": "Remove this AQ lane",
           "enabled": "Enable AQ lane",
           "triggers": "AQ triggers",
           "outputs": "AQ output devices",
@@ -387,15 +403,46 @@
           "action": "Alert to edit"
         }
       },
-      "options_alert_edit": {
-        "title": "Edit Alert",
-        "description": "Editing {alert_label}.",
+      "options_alert_add": {
+        "title": "Add Alert",
+        "description": "Configure a new high-priority alert automation.",
+        "errors": {
+          "alert_save_failed": "Failed to save alert configuration. Check logs and try again.",
+          "custom_trigger_required": "A custom binary sensor is required for Custom trigger type.",
+          "room_unknown": "Selected room is not in configured telemetry.",
+          "room_missing_humidity": "Selected room has no humidity telemetry for room-scoped humidity danger.",
+          "room_missing_temp_humidity": "Selected room needs both humidity and temperature telemetry for this room-scoped trigger."
+        },
         "data": {
           "enabled": "Enable alert",
           "trigger_type": "Trigger type",
           "custom_trigger": "Custom trigger entity (optional)",
           "threshold": "Threshold",
-          "lights": "Target lights",
+          "room": "Room scope (optional)",
+          "lights": "Target lights (optional)",
+          "outputs": "CO output devices (optional)",
+          "power_entity": "Power entity (optional)",
+          "flash_mode": "Flash mode",
+          "duration": "Flash duration"
+        }
+      },
+      "options_alert_edit": {
+        "title": "Edit Alert",
+        "description": "Editing {alert_label}.",
+        "errors": {
+          "alert_save_failed": "Failed to save alert configuration. Check logs and try again.",
+          "custom_trigger_required": "A custom binary sensor is required for Custom trigger type.",
+          "room_unknown": "Selected room is not in configured telemetry.",
+          "room_missing_humidity": "Selected room has no humidity telemetry for room-scoped humidity danger.",
+          "room_missing_temp_humidity": "Selected room needs both humidity and temperature telemetry for this room-scoped trigger."
+        },
+        "data": {
+          "enabled": "Enable alert",
+          "trigger_type": "Trigger type",
+          "custom_trigger": "Custom trigger entity (optional)",
+          "threshold": "Threshold",
+          "room": "Room scope (optional)",
+          "lights": "Target lights (optional)",
           "outputs": "CO output devices (optional)",
           "power_entity": "Power entity (optional)",
           "flash_mode": "Flash mode",

--- a/ui/cards/v2_mobile.yaml
+++ b/ui/cards/v2_mobile.yaml
@@ -664,17 +664,36 @@ card:
                 on('input_boolean.air_upstairs_humidifier_active');
               const fanIso = on('input_boolean.air_isolate_fan_outputs');
               const humIso = on('input_boolean.air_isolate_humidifier_outputs');
-
-              const showReason = danger || modeAlert || condAlert || mouldAlert || hasTemp || humidifying || fanIso || humIso || mode === 'manual_override' || mode === 'paused' || mode === 'away' || mode === 'global_gate';
-              if (!showReason) return `<div class="cv-reason"></div>`;
+              const alertOnlyUi =
+                !states['input_boolean.air_control_enabled'] &&
+                !states['input_boolean.air_control_output_expanded'] &&
+                !states['timer.air_control_pause'];
 
               let r = (states['sensor.air_control_reason']?.state || '').trim();
               const greenNoise = /\b(normal|all clear|idle|default|ok|okay|comfortable)\b/i.test(r);
-              if (greenNoise && !danger && !modeAlert && !hasTemp) r = '';
+              if (greenNoise && !danger && !modeAlert && !hasTemp && !alertOnlyUi) r = '';
+
+              const showReason =
+                danger ||
+                modeAlert ||
+                condAlert ||
+                mouldAlert ||
+                hasTemp ||
+                humidifying ||
+                fanIso ||
+                humIso ||
+                mode === 'manual_override' ||
+                mode === 'paused' ||
+                mode === 'away' ||
+                mode === 'global_gate' ||
+                !!r ||
+                alertOnlyUi;
+              if (!showReason) return `<div class="cv-reason"></div>`;
 
               const lines = [];
               if (on('input_boolean.air_co_emergency_active') || mode === 'co_emergency') {
-                lines.push('Stage: CO emergency override (all purifiers forced to 100%).');
+                if (alertOnlyUi) lines.push('Stage: CO emergency monitoring active (no automation output controls configured).');
+                else lines.push('Stage: CO emergency override (all purifiers forced to 100%).');
               } else if (activeAlertNames.length) {
                 lines.push(`Stage: Alert lane active (${activeAlertNames.join(', ')}).`);
               } else if (mode === 'global_gate' || mode === 'away') {
@@ -689,6 +708,8 @@ card:
                 lines.push('Stage: Air-quality assist running.');
               } else if (humidifying) {
                 lines.push('Stage: Humidifier assist running.');
+              } else if (alertOnlyUi) {
+                lines.push('Stage: Monitor + alerts only (no automation output controls configured).');
               } else if (mode === 'away') {
                 lines.push('Stage: Presence gate away (system disarmed).');
                 lines.push(`Presence: Alarm=${alarmState}, Justyna=${justynaHome ? 'home' : 'away'}, Senyo=${senyoHome ? 'home' : 'away'}.`);
@@ -701,13 +722,15 @@ card:
               if (condAlert) lines.push(`Risk: Condensation ${cap(condRaw)} in ${condRoom}.`);
               if (mouldAlert) lines.push(`Risk: Mould ${cap(mouldRaw)} in ${mouldRoom}.`);
 
-              if (tActive('timer.air_cooking_min_run')) lines.push('Timer: Zone 1 minimum runtime is active.');
-              if (tActive('timer.air_bathroom_min_run')) lines.push('Timer: Zone 2 minimum runtime is active.');
-              if (tActive('timer.air_aq_upstairs_run')) lines.push('Timer: Upstairs AQ run window is active.');
-              if (tActive('timer.air_aq_downstairs_run')) lines.push('Timer: Downstairs AQ run window is active.');
-              if (tActive('timer.air_control_pause')) lines.push('Timer: Pause window is active.');
-              if (fanIso) lines.push('Testing safeguard: Fan outputs are isolated, so fan service calls are suppressed.');
-              if (humIso) lines.push('Testing safeguard: Humidifier outputs are isolated, so humidifier service calls are suppressed.');
+              if (!alertOnlyUi) {
+                if (tActive('timer.air_cooking_min_run')) lines.push('Timer: Zone 1 minimum runtime is active.');
+                if (tActive('timer.air_bathroom_min_run')) lines.push('Timer: Zone 2 minimum runtime is active.');
+                if (tActive('timer.air_aq_upstairs_run')) lines.push('Timer: Upstairs AQ run window is active.');
+                if (tActive('timer.air_aq_downstairs_run')) lines.push('Timer: Downstairs AQ run window is active.');
+                if (tActive('timer.air_control_pause')) lines.push('Timer: Pause window is active.');
+                if (fanIso) lines.push('Testing safeguard: Fan outputs are isolated, so fan service calls are suppressed.');
+                if (humIso) lines.push('Testing safeguard: Humidifier outputs are isolated, so humidifier service calls are suppressed.');
+              }
 
               if (r) lines.push(`Engine: ${r}`);
               if (!lines.length) lines.push('Alert context active.');
@@ -758,6 +781,7 @@ card:
                 <span class="k">${k}</span>
                 <span class="v" style="color:${c};">${v === null ? '—' : v}${unit || ''}</span>
               </span>`;
+            const maybeChip = (k, v, unit, c) => (v === null ? '' : chip(k, v, unit, c));
 
             const iaqU = num('sensor.air_control_upstairs_iaq_average');
             const pmU  = num('sensor.air_control_upstairs_pm25_average');
@@ -772,15 +796,15 @@ card:
 
             return `
               <div class="cv-scroll">
-                ${chip('House IAQ', iaqH, '', cIAQ(iaqH))}
-                ${chip('Upstairs IAQ', iaqU, '', cIAQ(iaqU))}
-                ${chip('Upstairs PM2.5', pmU, '', cPM(pmU))}
-                ${chip('Upstairs VOC', vocU, '', cVOC(vocU))}
-                ${chip('Upstairs CO', coU, '', cCO(coU))}
-                ${chip('Downs.. IAQ', iaqD, '', cIAQ(iaqD))}
-                ${chip('Downs.. PM2.5', pmD, '', cPM(pmD))}
-                ${chip('Downs.. VOC', vocD, '', cVOC(vocD))}
-                ${chip('Downs.. CO', coD, '', cCO(coD))}
+                ${maybeChip('House IAQ', iaqH, '', cIAQ(iaqH))}
+                ${maybeChip('Upstairs IAQ', iaqU, '', cIAQ(iaqU))}
+                ${maybeChip('Upstairs PM2.5', pmU, '', cPM(pmU))}
+                ${maybeChip('Upstairs VOC', vocU, '', cVOC(vocU))}
+                ${maybeChip('Upstairs CO', coU, '', cCO(coU))}
+                ${maybeChip('Downs.. IAQ', iaqD, '', cIAQ(iaqD))}
+                ${maybeChip('Downs.. PM2.5', pmD, '', cPM(pmD))}
+                ${maybeChip('Downs.. VOC', vocD, '', cVOC(vocD))}
+                ${maybeChip('Downs.. CO', coD, '', cCO(coD))}
               </div>`;
           ]]]
         humidity: |

--- a/ui/cards/v2_tablet.yaml
+++ b/ui/cards/v2_tablet.yaml
@@ -483,17 +483,36 @@ card:
                 on('input_boolean.air_upstairs_humidifier_active');
               const fanIso = on('input_boolean.air_isolate_fan_outputs');
               const humIso = on('input_boolean.air_isolate_humidifier_outputs');
-
-              const showReason = danger || modeAlert || condAlert || mouldAlert || hasTemp || humidifying || fanIso || humIso || mode === 'manual_override' || mode === 'paused' || mode === 'away' || mode === 'global_gate';
-              if (!showReason) return `<div class="cv-reason"></div>`;
+              const alertOnlyUi =
+                !states['input_boolean.air_control_enabled'] &&
+                !states['input_boolean.air_control_output_expanded'] &&
+                !states['timer.air_control_pause'];
 
               let r = (states['sensor.air_control_reason']?.state || '').trim();
               const greenNoise = /\b(normal|all clear|idle|default|ok|okay|comfortable)\b/i.test(r);
-              if (greenNoise && !danger && !modeAlert && !hasTemp) r = '';
+              if (greenNoise && !danger && !modeAlert && !hasTemp && !alertOnlyUi) r = '';
+
+              const showReason =
+                danger ||
+                modeAlert ||
+                condAlert ||
+                mouldAlert ||
+                hasTemp ||
+                humidifying ||
+                fanIso ||
+                humIso ||
+                mode === 'manual_override' ||
+                mode === 'paused' ||
+                mode === 'away' ||
+                mode === 'global_gate' ||
+                !!r ||
+                alertOnlyUi;
+              if (!showReason) return `<div class="cv-reason"></div>`;
 
               const lines = [];
               if (on('input_boolean.air_co_emergency_active') || mode === 'co_emergency') {
-                lines.push('Stage: CO emergency override (all purifiers forced to 100%).');
+                if (alertOnlyUi) lines.push('Stage: CO emergency monitoring active (no automation output controls configured).');
+                else lines.push('Stage: CO emergency override (all purifiers forced to 100%).');
               } else if (activeAlertNames.length) {
                 lines.push(`Stage: Alert lane active (${activeAlertNames.join(', ')}).`);
               } else if (mode === 'global_gate' || mode === 'away') {
@@ -508,6 +527,8 @@ card:
                 lines.push('Stage: Air-quality assist running.');
               } else if (humidifying) {
                 lines.push('Stage: Humidifier assist running.');
+              } else if (alertOnlyUi) {
+                lines.push('Stage: Monitor + alerts only (no automation output controls configured).');
               } else if (mode === 'away') {
                 lines.push('Stage: Presence gate away (system disarmed).');
                 lines.push(`Presence: Alarm=${alarmState}, Justyna=${justynaHome ? 'home' : 'away'}, Senyo=${senyoHome ? 'home' : 'away'}.`);
@@ -520,13 +541,15 @@ card:
               if (condAlert) lines.push(`Risk: Condensation ${cap(condRaw)} in ${condRoom}.`);
               if (mouldAlert) lines.push(`Risk: Mould ${cap(mouldRaw)} in ${mouldRoom}.`);
 
-              if (tActive('timer.air_cooking_min_run')) lines.push('Timer: Zone 1 minimum runtime is active.');
-              if (tActive('timer.air_bathroom_min_run')) lines.push('Timer: Zone 2 minimum runtime is active.');
-              if (tActive('timer.air_aq_upstairs_run')) lines.push('Timer: Upstairs AQ run window is active.');
-              if (tActive('timer.air_aq_downstairs_run')) lines.push('Timer: Downstairs AQ run window is active.');
-              if (tActive('timer.air_control_pause')) lines.push('Timer: Pause window is active.');
-              if (fanIso) lines.push('Testing safeguard: Fan outputs are isolated, so fan service calls are suppressed.');
-              if (humIso) lines.push('Testing safeguard: Humidifier outputs are isolated, so humidifier service calls are suppressed.');
+              if (!alertOnlyUi) {
+                if (tActive('timer.air_cooking_min_run')) lines.push('Timer: Zone 1 minimum runtime is active.');
+                if (tActive('timer.air_bathroom_min_run')) lines.push('Timer: Zone 2 minimum runtime is active.');
+                if (tActive('timer.air_aq_upstairs_run')) lines.push('Timer: Upstairs AQ run window is active.');
+                if (tActive('timer.air_aq_downstairs_run')) lines.push('Timer: Downstairs AQ run window is active.');
+                if (tActive('timer.air_control_pause')) lines.push('Timer: Pause window is active.');
+                if (fanIso) lines.push('Testing safeguard: Fan outputs are isolated, so fan service calls are suppressed.');
+                if (humIso) lines.push('Testing safeguard: Humidifier outputs are isolated, so humidifier service calls are suppressed.');
+              }
 
               if (r) lines.push(`Engine: ${r}`);
               if (!lines.length) lines.push('Alert context active.');
@@ -577,6 +600,7 @@ card:
                 <span class="k">${k}</span>
                 <span class="v" style="color:${c};">${v === null ? '—' : v}${unit || ''}</span>
               </span>`;
+            const maybeChip = (k, v, unit, c) => (v === null ? '' : chip(k, v, unit, c));
 
             const iaqU = num('sensor.air_control_upstairs_iaq_average');
             const pmU  = num('sensor.air_control_upstairs_pm25_average');
@@ -591,15 +615,15 @@ card:
 
             return `
               <div class="cv-scroll">
-                ${chip('House IAQ', iaqH, '', cIAQ(iaqH))}
-                ${chip('Upstairs IAQ', iaqU, '', cIAQ(iaqU))}
-                ${chip('Upstairs PM2.5', pmU, '', cPM(pmU))}
-                ${chip('Upstairs VOC', vocU, '', cVOC(vocU))}
-                ${chip('Upstairs CO', coU, '', cCO(coU))}
-                ${chip('Downs.. IAQ', iaqD, '', cIAQ(iaqD))}
-                ${chip('Downs.. PM2.5', pmD, '', cPM(pmD))}
-                ${chip('Downs.. VOC', vocD, '', cVOC(vocD))}
-                ${chip('Downs.. CO', coD, '', cCO(coD))}
+                ${maybeChip('House IAQ', iaqH, '', cIAQ(iaqH))}
+                ${maybeChip('Upstairs IAQ', iaqU, '', cIAQ(iaqU))}
+                ${maybeChip('Upstairs PM2.5', pmU, '', cPM(pmU))}
+                ${maybeChip('Upstairs VOC', vocU, '', cVOC(vocU))}
+                ${maybeChip('Upstairs CO', coU, '', cCO(coU))}
+                ${maybeChip('Downs.. IAQ', iaqD, '', cIAQ(iaqD))}
+                ${maybeChip('Downs.. PM2.5', pmD, '', cPM(pmD))}
+                ${maybeChip('Downs.. VOC', vocD, '', cVOC(vocD))}
+                ${maybeChip('Downs.. CO', coD, '', cCO(coD))}
               </div>`;
           ]]]
         humidity: |

--- a/ui/register.py
+++ b/ui/register.py
@@ -22,6 +22,27 @@ _LOGGER = logging.getLogger(__name__)
 
 from pathlib import Path
 
+_ALERT_ONLY_HIDDEN_BOOL_KEYS = {
+    "air_control_enabled",
+    "air_control_manual_override",
+    "air_control_output_expanded",
+    "air_isolate_fan_outputs",
+    "air_isolate_humidifier_outputs",
+    "air_aq_downstairs_active",
+    "air_aq_upstairs_active",
+    "air_downstairs_humidifier_active",
+    "air_upstairs_humidifier_active",
+    "humidity_constellation_expanded",
+    "toggle",
+}
+_ALERT_ONLY_HIDDEN_TIMER_KEYS = {
+    "air_aq_upstairs_run",
+    "air_aq_downstairs_run",
+    "air_bathroom_min_run",
+    "air_cooking_min_run",
+    "air_control_pause",
+}
+
 
 async def async_build_entity_mapping(hass: HomeAssistant, entry_id: str) -> Dict[str, str]:
     """Build mapping from v1 placeholder entity IDs to v2 entity IDs."""
@@ -33,6 +54,7 @@ async def async_build_entity_mapping(hass: HomeAssistant, entry_id: str) -> Dict
     zones = _entry_section(entry, "zones", {}) if entry else {}
     humidifiers = _entry_section(entry, "humidifiers", {}) if entry else {}
     alerts = _entry_section(entry, "alerts", []) if entry else []
+    alert_only_mode = bool(_entry_section(entry, "alert_only_mode", False)) if entry else False
 
     def _find_telemetry(room_hint: str, sensor_type: str, level: str | None = None) -> str | None:
         room_hint = room_hint.lower()
@@ -102,9 +124,16 @@ async def async_build_entity_mapping(hass: HomeAssistant, entry_id: str) -> Dict
             return lights[index]
         return None
 
-    def _bool_entity_id(key: str) -> str:
+    def _bool_entity_id(key: str) -> str | None:
+        if alert_only_mode and key in _ALERT_ONLY_HIDDEN_BOOL_KEYS:
+            return None
         unique_id = f"hi_{entry_id}_input_{key}"
-        return registry.async_get_entity_id("switch", DOMAIN, unique_id) or f"switch.hi_{key}"
+        found = registry.async_get_entity_id("switch", DOMAIN, unique_id)
+        if found:
+            return found
+        if alert_only_mode and key in _ALERT_ONLY_HIDDEN_BOOL_KEYS:
+            return None
+        return f"switch.hi_{key}"
 
     def _alert_active_entity(index: int) -> str | None:
         if index >= len(alerts or []):
@@ -116,9 +145,16 @@ async def async_build_entity_mapping(hass: HomeAssistant, entry_id: str) -> Dict
             return found
         return f"switch.hi_{key}"
 
-    def _timer_entity_id(key: str) -> str:
+    def _timer_entity_id(key: str) -> str | None:
+        if alert_only_mode and key in _ALERT_ONLY_HIDDEN_TIMER_KEYS:
+            return None
         unique_id = f"hi_{entry_id}_timer_{key}"
-        return registry.async_get_entity_id("sensor", DOMAIN, unique_id) or f"sensor.hi_{key}"
+        found = registry.async_get_entity_id("sensor", DOMAIN, unique_id)
+        if found:
+            return found
+        if alert_only_mode and key in _ALERT_ONLY_HIDDEN_TIMER_KEYS:
+            return None
+        return f"sensor.hi_{key}"
 
     placeholders = {
         "sensor.house_average_humidity": _entity_id("sensor", "house_avg_humidity"),
@@ -319,6 +355,9 @@ async def async_register_cards(hass: HomeAssistant, entry_id: str, mapping: Dict
             content = re.sub(pattern, entity_id, content)
 
         content = _prune_unresolved_entity_items(content, unresolved)
+        content = _prune_empty_card_lists(content)
+        content = _prune_invalid_conditional_cards(content)
+        content = _prune_empty_card_lists(content)
 
         unresolved_in_card: List[str] = []
         for placeholder in unresolved:
@@ -356,7 +395,10 @@ def _is_optional_placeholder(placeholder: str) -> bool:
             "fan.",
             "humidifier.",
             "light.",
-            "input_boolean.air_alert_",
+            "timer.air_",
+            "input_boolean.air_",
+            "input_boolean.humidity_constellation_",
+            "input_boolean.toggle",
         )
     )
 
@@ -364,8 +406,13 @@ def _is_optional_placeholder(placeholder: str) -> bool:
 def _should_prune_unresolved_entity_line(placeholder: str) -> bool:
     return placeholder.startswith(
         (
-            "light.alert_",
-            "input_boolean.air_alert_",
+            "fan.",
+            "humidifier.",
+            "light.",
+            "timer.air_",
+            "input_boolean.air_",
+            "input_boolean.humidity_constellation_",
+            "input_boolean.toggle",
         )
     )
 
@@ -378,39 +425,263 @@ def _prune_unresolved_entity_items(content: str, unresolved: List[str]) -> str:
     lines = content.splitlines()
     out: List[str] = []
     i = 0
-    entity_pattern = re.compile(r"^([ \t]*)-[ \t]*entity:[ \t]*([^#\s]+)[ \t]*(?:#.*)?$")
+    list_entity_pattern = re.compile(r"^([ \t]*)-[ \t]*entity:[ \t]*([^#\s]+)[ \t]*(?:#.*)?$")
+    entity_line_pattern = re.compile(r"^([ \t]*)entity:[ \t]*([^#\s]+)[ \t]*(?:#.*)?$")
 
     while i < len(lines):
         line = lines[i]
-        match = entity_pattern.match(line)
-        if not match:
+
+        list_match = list_entity_pattern.match(line)
+        if list_match:
+            entity_id = list_match.group(2)
+            if entity_id in prune_set:
+                base_indent = len(list_match.group(1))
+                i = _skip_yaml_block(lines, i + 1, base_indent)
+                continue
             out.append(line)
             i += 1
             continue
 
-        entity_id = match.group(2)
+        entity_match = entity_line_pattern.match(line)
+        if not entity_match:
+            out.append(line)
+            i += 1
+            continue
+
+        entity_id = entity_match.group(2)
         if entity_id not in prune_set:
             out.append(line)
             i += 1
             continue
 
-        # Drop this list item and its child mapping lines.
-        base_indent = len(match.group(1))
+        base_indent = len(entity_match.group(1))
+        parent_start = _find_parent_list_item_index(out, base_indent)
+        if parent_start is not None:
+            parent_indent = len(out[parent_start]) - len(out[parent_start].lstrip(" \t"))
+            out = out[:parent_start]
+            i = _skip_yaml_block(lines, i + 1, parent_indent)
+            continue
+
         i += 1
-        while i < len(lines):
-            nxt = lines[i]
-            if not nxt.strip():
-                i += 1
-                continue
-            indent = len(nxt) - len(nxt.lstrip(" \t"))
-            if indent <= base_indent:
-                break
-            i += 1
 
     result = "\n".join(out)
     if content.endswith("\n"):
         result += "\n"
     return result
+
+
+def _prune_empty_card_lists(content: str) -> str:
+    """Drop card containers that end up with empty cards lists after pruning."""
+    current = content
+    while True:
+        updated = _prune_empty_card_lists_once(current)
+        if updated == current:
+            return updated
+        current = updated
+
+
+def _prune_empty_card_lists_once(content: str) -> str:
+    lines = content.splitlines()
+    out: List[str] = []
+    i = 0
+    card_item_pattern = re.compile(r"^([ \t]*)-[ \t]*type:[ \t]*([^#\s]+)[ \t]*(?:#.*)?$")
+
+    while i < len(lines):
+        line = lines[i]
+        match = card_item_pattern.match(line)
+        if not match:
+            out.append(line)
+            i += 1
+            continue
+
+        base_indent = len(match.group(1))
+        end = i + 1
+        while end < len(lines):
+            nxt = lines[end]
+            if not nxt.strip():
+                end += 1
+                continue
+            nxt_indent = len(nxt) - len(nxt.lstrip(" \t"))
+            if nxt_indent <= base_indent and nxt.lstrip().startswith("- "):
+                break
+            end += 1
+
+        block = lines[i:end]
+        if _block_has_empty_cards_list(block):
+            i = end
+            continue
+
+        out.extend(block)
+        i = end
+
+    result = "\n".join(out)
+    if content.endswith("\n"):
+        result += "\n"
+    return result
+
+
+def _block_has_empty_cards_list(block: List[str]) -> bool:
+    cards_pattern = re.compile(r"^([ \t]*)cards:[ \t]*(?:#.*)?$")
+    for idx, line in enumerate(block):
+        match = cards_pattern.match(line)
+        if not match:
+            continue
+        cards_indent = len(match.group(1))
+        next_idx = idx + 1
+        while next_idx < len(block):
+            nxt = block[next_idx]
+            if not nxt.strip():
+                next_idx += 1
+                continue
+            nxt_indent = len(nxt) - len(nxt.lstrip(" \t"))
+            if nxt_indent <= cards_indent:
+                return True
+            break
+        else:
+            return True
+    return False
+
+
+def _prune_invalid_conditional_cards(content: str) -> str:
+    """Drop conditional cards that become invalid after entity pruning."""
+    current = content
+    while True:
+        updated = _prune_invalid_conditional_cards_once(current)
+        if updated == current:
+            return updated
+        current = updated
+
+
+def _prune_invalid_conditional_cards_once(content: str) -> str:
+    lines = content.splitlines()
+    out: List[str] = []
+    i = 0
+    conditional_pattern = re.compile(r"^([ \t]*)-[ \t]*type:[ \t]*conditional[ \t]*(?:#.*)?$")
+
+    while i < len(lines):
+        line = lines[i]
+        match = conditional_pattern.match(line)
+        if not match:
+            out.append(line)
+            i += 1
+            continue
+
+        base_indent = len(match.group(1))
+        end = i + 1
+        while end < len(lines):
+            nxt = lines[end]
+            if not nxt.strip():
+                end += 1
+                continue
+            nxt_indent = len(nxt) - len(nxt.lstrip(" \t"))
+            if nxt_indent <= base_indent and nxt.lstrip().startswith("- "):
+                break
+            end += 1
+
+        block = lines[i:end]
+        if _is_invalid_conditional_block(block):
+            i = end
+            continue
+
+        out.extend(block)
+        i = end
+
+    result = "\n".join(out)
+    if content.endswith("\n"):
+        result += "\n"
+    return result
+
+
+def _is_invalid_conditional_block(block: List[str]) -> bool:
+    if not block:
+        return True
+
+    base_indent = len(block[0]) - len(block[0].lstrip(" \t"))
+    top_level_key_pattern = re.compile(r"^([ \t]*)([A-Za-z_][A-Za-z0-9_-]*):[ \t]*(?:#.*)?$")
+    top_level_indent = base_indent + 2
+
+    conditions_idx: int | None = None
+    conditions_indent: int | None = None
+    card_idx: int | None = None
+    card_indent: int | None = None
+
+    for idx, line in enumerate(block[1:], start=1):
+        match = top_level_key_pattern.match(line)
+        if not match:
+            continue
+        indent = len(match.group(1))
+        if indent != top_level_indent:
+            continue
+        key = match.group(2)
+        if key == "conditions" and conditions_idx is None:
+            conditions_idx = idx
+            conditions_indent = indent
+        elif key == "card" and card_idx is None:
+            card_idx = idx
+            card_indent = indent
+
+    if conditions_idx is None or conditions_indent is None:
+        return True
+    if card_idx is None or card_indent is None:
+        return True
+
+    has_condition_item = False
+    j = conditions_idx + 1
+    while j < len(block):
+        line = block[j]
+        if not line.strip():
+            j += 1
+            continue
+        indent = len(line) - len(line.lstrip(" \t"))
+        if indent <= conditions_indent:
+            break
+        if line.lstrip().startswith("- "):
+            has_condition_item = True
+            break
+        j += 1
+    if not has_condition_item:
+        return True
+
+    has_card_body = False
+    j = card_idx + 1
+    while j < len(block):
+        line = block[j]
+        if not line.strip():
+            j += 1
+            continue
+        indent = len(line) - len(line.lstrip(" \t"))
+        if indent <= card_indent:
+            break
+        has_card_body = True
+        break
+    return not has_card_body
+
+
+def _find_parent_list_item_index(lines: List[str], entity_indent: int) -> int | None:
+    for idx in range(len(lines) - 1, -1, -1):
+        line = lines[idx]
+        if not line.strip():
+            continue
+        indent = len(line) - len(line.lstrip(" \t"))
+        if indent >= entity_indent:
+            continue
+        if line.lstrip().startswith("- "):
+            return idx
+    return None
+
+
+def _skip_yaml_block(lines: List[str], start_index: int, base_indent: int) -> int:
+    index = start_index
+    while index < len(lines):
+        line = lines[index]
+        if not line.strip():
+            index += 1
+            continue
+        indent = len(line) - len(line.lstrip(" \t"))
+        if indent <= base_indent and line.lstrip().startswith("- "):
+            break
+        index += 1
+    return index
 
 
 def _entry_section(entry: Any, key: str, default: Any) -> Any:


### PR DESCRIPTION
### v2.0.1 fixes

- fixed Fahrenheit telemetry normalization by converting all internal temperature math to Celsius before averages, spreads, deltas, and thresholds
- fixed aggregate behavior so IAQ/AQ averages ignore `unknown`, `unavailable`, and non-numeric states and only return unknown when no valid values exist
- added aggregate exclusion debug logging with explicit reasons (`unknown`, `unavailable`, `non_numeric`, `unit_mismatch`)
- added zone mapping duplicate warnings in setup/options and new duplicate diagnostics sensor state
- added `alert_only_mode` (monitor + alerts only) to suppress automation control lanes for users without output hardware
- improved UI placeholder pruning so optional outputs/controls are hidden when not configured, including alert-only control suppression
- fixed alert-only card rendering edge case by pruning invalid leftover `conditional` blocks after entity pruning
- updated Current Air Control reason field behavior for alert-only mode so it reports monitoring/alerts context and does not imply missing output controls
- options changes that flip `alert_only_mode` now trigger UI card refresh/export regeneration and a notification
- expanded options flow editing so users can revisit skipped lanes and add/edit alerts later
- expanded post-configuration lane management so humidifier and AQ lanes can be re-added after removal, and telemetry changes log explicit add/update/remove actions
- alert target lights are now fully optional end-to-end (config/options/service/runtime); alerts still trigger without flash entities
- hardened service input validation (safe filename/url path/layout checks), bounded flash parameters, and diagnostics attribute redaction for sensitive keys
