### PR TITLE
fix: allow exact release branch version governance

### DIFF
--- a/docs/release-governance.md
+++ b/docs/release-governance.md
@@ -19,6 +19,9 @@ Home Assistant and HACS metadata checks.
 - `develop`: release-candidate or stable version metadata only. Beta labels stay on
   `senyo888-patch-1`.
 - `main`: stable production version metadata only. No prerelease suffix is allowed.
+- `vMAJOR.MINOR.PATCH`: release-verification branch for the exact matching stable
+  manifest version only. For example, `v2.0.5` may carry `2.0.5`, but not
+  `2.0.5-rc.1` or `2.0.6`.
 - Short-lived development branches, including `Bella/*`, `codex/*`, `feature/*`,
   `fix/*`, `patch/*`, and `test/*`, must not carry stable manifest versions.
 
@@ -28,7 +31,9 @@ Home Assistant and HACS metadata checks.
 2. Promotion to `develop` uses `MAJOR.MINOR.PATCH-rc.N` or stable
    `MAJOR.MINOR.PATCH` version metadata only.
 3. Promotion to `main` uses stable `MAJOR.MINOR.PATCH` version metadata only.
-4. A GitHub release is created only from a stable version on `main`.
+4. Exact `vMAJOR.MINOR.PATCH` branches may be used for stable release-verification CI,
+   but they do not replace the `main` release/tag gate.
+5. A GitHub release is created only from a stable version on `main`.
 
 ## Hard Release Gates
 
@@ -57,8 +62,9 @@ in CI. It rejects:
 - prerelease versions on `main`
 - beta versions on `develop`
 - stable versions on short-lived testing branches
+- prerelease or mismatched stable versions on `vMAJOR.MINOR.PATCH` branches
 - stable versions on unapproved branches outside `senyo888-patch-1`, `develop`, and
-  `main`
+  `main`, plus exact matching `vMAJOR.MINOR.PATCH` release-verification branches
 
 This is a release-boundary guard only. It does not alter runtime logic, entity
 semantics, generated dashboards, or Home Assistant services.

--- a/scripts/check_version_governance.py
+++ b/scripts/check_version_governance.py
@@ -17,6 +17,9 @@ VERSION_PATTERN = re.compile(
     r"(?P<patch>0|[1-9]\d*)"
     r"(?:-(?P<label>beta|rc)\.(?P<number>[1-9]\d*))?$"
 )
+RELEASE_BRANCH_PATTERN = re.compile(
+    r"^v(?P<version>(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*))$"
+)
 
 TESTING_BRANCH_PREFIXES = (
     "Bella/",
@@ -63,6 +66,13 @@ def _is_testing_branch(branch: str) -> bool:
     return branch.startswith(TESTING_BRANCH_PREFIXES)
 
 
+def _release_branch_version(branch: str) -> str | None:
+    match = RELEASE_BRANCH_PATTERN.fullmatch(branch)
+    if not match:
+        return None
+    return match.group("version")
+
+
 def main() -> int:
     branch = _active_branch()
     version = _manifest_version()
@@ -79,6 +89,15 @@ def main() -> int:
         return 1
 
     label = match.group("label")
+    release_branch_version = _release_branch_version(branch)
+
+    if release_branch_version and version != release_branch_version:
+        print(
+            f"Release branch '{branch}' must carry matching stable version "
+            f"'{release_branch_version}', not '{version}'.",
+            file=sys.stderr,
+        )
+        return 1
 
     if branch == "main" and label:
         print(
@@ -94,7 +113,7 @@ def main() -> int:
         )
         return 1
 
-    if not label and branch not in STABLE_ALLOWED_BRANCHES:
+    if not label and branch not in STABLE_ALLOWED_BRANCHES and not release_branch_version:
         print(
             f"Branch '{branch}' must not carry stable version '{version}'.",
             file=sys.stderr,

--- a/tests 2/test_version_governance.py
+++ b/tests 2/test_version_governance.py
@@ -1,0 +1,66 @@
+"""Regression checks for branch/version release governance."""
+
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import io
+import pathlib
+import sys
+import unittest
+from unittest import mock
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "check_version_governance.py"
+
+
+def _load_version_governance():
+    spec = importlib.util.spec_from_file_location("check_version_governance", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    sys.modules["check_version_governance"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class VersionGovernanceTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.governance = _load_version_governance()
+
+    def _run_check(self, *, branch: str, version: str) -> tuple[int, str, str]:
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        with mock.patch.object(self.governance, "_active_branch", return_value=branch):
+            with mock.patch.object(self.governance, "_manifest_version", return_value=version):
+                with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+                    result = self.governance.main()
+        return result, stdout.getvalue(), stderr.getvalue()
+
+    def test_exact_release_branch_may_carry_matching_stable_version(self) -> None:
+        result, stdout, stderr = self._run_check(branch="v2.0.5", version="2.0.5")
+
+        self.assertEqual(result, 0, stderr)
+        self.assertIn("Version governance OK", stdout)
+
+    def test_release_branch_rejects_prerelease_version(self) -> None:
+        result, _stdout, stderr = self._run_check(branch="v2.0.5", version="2.0.5-rc.1")
+
+        self.assertEqual(result, 1)
+        self.assertIn("Release branch 'v2.0.5' must carry matching stable version", stderr)
+
+    def test_release_branch_rejects_mismatched_stable_version(self) -> None:
+        result, _stdout, stderr = self._run_check(branch="v2.0.5", version="2.0.6")
+
+        self.assertEqual(result, 1)
+        self.assertIn("Release branch 'v2.0.5' must carry matching stable version", stderr)
+
+    def test_testing_branch_still_rejects_stable_version(self) -> None:
+        result, _stdout, stderr = self._run_check(branch="fix/version-check", version="2.0.5")
+
+        self.assertEqual(result, 1)
+        self.assertIn("must not carry stable version", stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

<!-- Governance Fix -->

## Type

- [x ] Fix
- [ ] Feature
- [ ] Documentation
- [ ] UI Gallery
- [ ] Maintenance

## Checks

- [ ] PR targets `develop`.
- [ ] Tested in Home Assistant, or testing notes explain why not. (governance fix, not needed)
- [ ] Restart/config flow checked where relevant.
- [ ] Ran `humidity_intelligence.refresh_ui` or refreshed dashboards where UI output changed.
- [x] Docs/changelog updated where needed.
- [ x] Support docs, diagnostics guidance, and issue templates updated where support flow changed.
- [ x] No private entity IDs, secrets, addresses, or personal data included.
- [ x] HACS/custom integration metadata still looks correct.

## UI Gallery submissions

- [ ] Uses `/ui-gallery/<card-id>/`.
- [ ] Includes `README.md`, `preview.png`, and `card.yaml` or `dashboard.yaml`.
- [ ] Top-level `ui-gallery/README.md` is updated.
- [ ] Example follows `ui-gallery/reference.txt` format.
- [ ] Required custom cards are documented.
- [ ] Preserves canonical Humidity Intelligence backend entities/helpers.
- [ ] Screenshots and YAML contain no private entity IDs, secrets, addresses, device IDs, tokens, internal URLs, or personal data.
