### PR TITLE
pr-051451f-v206b1-release-check-fix

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -10,7 +10,7 @@ body:
 
         Settings -> Devices & services -> Humidity Intelligence -> Download diagnostics
 
-        Attach the downloaded file below. This helps maintainers understand your setup without asking lots of follow-up questions.
+        Attach the downloaded file below. This is preferred over pasting a dump_diagnostics export unless a maintainer asks for that fuller local JSON.
 
         Please review the bundle before attaching if you are concerned about privacy. The bundle is designed to redact sensitive values, but you remain in control of what you upload.
   - type: textarea
@@ -24,7 +24,7 @@ body:
     attributes:
       label: Humidity Intelligence version (fallback)
       description: Optional if diagnostics are attached.
-      placeholder: "2.0.4"
+      placeholder: "2.0.5"
   - type: input
     id: ha-version
     attributes:

--- a/.github/ISSUE_TEMPLATE/config_help.yml
+++ b/.github/ISSUE_TEMPLATE/config_help.yml
@@ -10,7 +10,7 @@ body:
 
         Settings -> Devices & services -> Humidity Intelligence -> Download diagnostics
 
-        Attach the downloaded file below. This helps maintainers understand your setup without asking lots of follow-up questions.
+        Attach the downloaded file below. This is preferred over pasting a dump_diagnostics export unless a maintainer asks for that fuller local JSON.
 
         Please review the bundle before attaching if you are concerned about privacy. The bundle is designed to redact sensitive values, but you remain in control of what you upload.
   - type: textarea
@@ -19,6 +19,18 @@ body:
       label: Attach your Humidity Intelligence diagnostics file
       description: Drag the downloaded Home Assistant diagnostics file here, or write "Unable to download diagnostics" and answer the setup questions below.
       render: text
+  - type: input
+    id: hi-version
+    attributes:
+      label: Humidity Intelligence version (fallback)
+      description: Optional if diagnostics are attached.
+      placeholder: "2.0.5"
+  - type: input
+    id: ha-version
+    attributes:
+      label: Home Assistant version (fallback)
+      description: Optional if diagnostics are attached.
+      placeholder: "2026.4.3"
   - type: dropdown
     id: affected-area
     attributes:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,6 +2,38 @@
 
 <!-- What changed and why? -->
 
+## Scope
+
+<!-- Files/areas affected. Keep the scope small and explicit. -->
+
+## Reason
+
+<!-- Why this change is needed now. -->
+
+## Files affected
+
+<!-- List the main files or folders touched. -->
+
+## Runtime impact
+
+<!-- State whether lane ordering, entity semantics, services, outputs, diagnostics, or migrations changed. -->
+
+## UI impact
+
+<!-- State whether generated dashboards, cards, gallery examples, or frontend dependency assumptions changed. -->
+
+## Migration impact
+
+<!-- State whether users need to take action. If none, say "None". -->
+
+## Rollback safety
+
+<!-- State how this can be reverted safely if it regresses. -->
+
+## Validation performed
+
+<!-- Commands, Home Assistant checks, generated-card checks, or docs checks run. -->
+
 ## Type
 
 - [ ] Fix
@@ -20,6 +52,10 @@
 - [ ] Support docs, diagnostics guidance, and issue templates updated where support flow changed.
 - [ ] No private entity IDs, secrets, addresses, or personal data included.
 - [ ] HACS/custom integration metadata still looks correct.
+- [ ] Deterministic lane ordering is preserved, or the PR explicitly explains an approved semantic change.
+- [ ] UI truth consistency is preserved; generated UI does not invent backend state.
+- [ ] Migration impact is documented, including "none" when no migration is required.
+- [ ] Release/readiness impact is stated, including whether Bella/Aetherwing/AetherCore review is needed.
 
 ## UI Gallery submissions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,7 @@ Humidity Intelligence is a deterministic Home Assistant environmental control en
 
 - Keep `README.md`, `manifest.json`, `hacs.json`, docs, release notes, UI examples, and runtime behavior aligned.
 - Update related docs when implementation behavior changes.
+- Treat completed milestones as completed. Do not leave shipped v2.0.5 functionality in planned, pending, or proposal-only roadmap buckets.
 - Keep branch/version state explicit: `senyo888-patch-1` may carry beta, rc, or stable labels; `develop` may carry rc or stable labels; `main` carries stable releases only.
 - Run the version-governance check before release promotion so unstable builds cannot be promoted as stable by accident.
 - Treat release tagging as blocked until Bella verification, AetherCore governance verification, release sanity validation, and maintainer README approval are complete.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This project follows a practical changelog format for Home Assistant and HACS us
 
 ## Unreleased
 
-No changes yet.
+- Synchronized roadmap, governance, support, and contributor documentation to treat v2.0.5 as a completed release milestone while keeping future v2.1 work explicitly staged.
 
 ## 2.0.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project follows a practical changelog format for Home Assistant and HACS us
 ## Unreleased
 
 - Synchronized roadmap, governance, support, and contributor documentation to treat v2.0.5 as a completed release milestone while keeping future v2.1 work explicitly staged.
+- Kept `v205_release_check` compatible with v2.0.6 beta/rc/stable manifests so the v2.0.6 beta 1 validation path reuses the existing read-only release-check contract instead of renaming the service.
 
 ## 2.0.5
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,13 +17,9 @@ Before opening a PR:
 
 ## HACS custom integration context
 
-Humidity Intelligence is a structured Home Assistant custom integration. HACS integration repositories should contain one integration per repository, with runtime files under:
+Humidity Intelligence is a structured Home Assistant custom integration. This repository currently uses root-content HACS packaging (`content_in_root: true`), and CI stages the package into `custom_components/humidity_intelligence/` for Home Assistant/Hassfest validation.
 
-```text
-custom_components/humidity_intelligence/
-```
-
-Do not add unrelated integrations to this repository. Keep HACS metadata, integration metadata, and documentation aligned with the current release.
+Do not add unrelated integrations to this repository. Keep `hacs.json`, `manifest.json`, README installation guidance, release notes, and CI packaging assumptions aligned with the current release layout.
 
 ## UI Gallery submissions
 
@@ -73,7 +69,7 @@ Update `README.md`, docs, services documentation, or UI Gallery README files whe
 
 ## Bug reports and review process
 
-Use the GitHub issue forms for bugs, feature requests, configuration help, and UI Gallery submissions. A good bug report includes the Humidity Intelligence version, Home Assistant version, install method, logs, expected behavior, actual behavior, and steps to reproduce.
+Use the GitHub issue forms for bugs, feature requests, configuration help, and UI Gallery submissions. For bug/configuration reports, attach the native Home Assistant diagnostics file for Humidity Intelligence when possible. If diagnostics cannot be downloaded, include the Humidity Intelligence version, Home Assistant version, install method, logs, expected behavior, actual behavior, checks already tried, and steps to reproduce.
 
 Maintainers can use the report-only daily triage helper documented in [docs/issue-triage.md](docs/issue-triage.md) to review new, untriaged, or recently updated issues without mutating GitHub issue state.
 

--- a/README.md
+++ b/README.md
@@ -961,7 +961,8 @@ data: {}
 
 ### `v205_release_check`
 Purpose:
-- run a read-only v2.0.5 release-validation report in Home Assistant.
+- run a read-only release-validation report in Home Assistant for the v2.0.5/v2.0.6 maintenance line.
+- keep the `v205_release_check` service name for compatibility; v2.0.6 beta/rc/stable builds still use the same generated-card and `dump_cards` contract.
 - verify generated-card output-details visibility, cached layout coverage, unresolved placeholders, card text sanity, configured entity availability, house humidity drift dependency status, and optional frontend dependency status.
 - with `write_test_exports: true`, write test card exports proving unscoped `dump_cards` exports all layouts and scoped export writes only `v2_tablet`.
 - no runtime outputs, helpers, lanes, or configured entities are changed.

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@
 
 # Humidity Intelligence
 
-## Domestic Environmental Control Engine for Home Assistant
+## Domestic Environmental Stabilisation Engine for Home Assistant
 
 [![Latest Release](https://img.shields.io/github/v/release/senyo888/Humidity-Intelligence?display_name=tag&sort=semver)](https://github.com/senyo888/Humidity-Intelligence/releases)
 [![HACS](https://img.shields.io/badge/HACS-Custom%20Integration-orange)](https://hacs.xyz)
-[![Home Assistant](https://img.shields.io/badge/Home%20Assistant-2026.4.3%2B-blue)](https://www.home-assistant.io/)
+[![Integration Version](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Fsenyo888%2FHumidity-Intelligence%2Fmain%2Fmanifest.json&query=%24.version&label=Integration&prefix=v&color=blue)](manifest.json)
 [![License](https://img.shields.io/github/license/senyo888/Humidity-Intelligence)](LICENSE)
 
 ## Contents
@@ -16,7 +16,7 @@
 - [TL;DR](#tldr)
 - [What Is Humidity Intelligence](#what-is-humidity-intelligence)
 - [V2 UI Example](#v2-ui-example)
-- [Support Project](#support-project)
+- [Support Humidity Intelligence](#support-humidity-intelligence)
 - [Why Environmental Stability Matters](#why-environmental-stability-matters)
 - [Season-Aware Environmental Control](#season-aware-environmental-control)
 - [Design Philosophy](#design-philosophy)
@@ -37,11 +37,11 @@
 
 ## TL;DR
 
-Humidity Intelligence is a domestic environmental control engine for Home Assistant.
+Humidity Intelligence is a domestic environmental stabilisation engine for Home Assistant.
 
 It reads humidity, temperature, air quality, condensation, mould-risk, CO, presence, time, pause, and override signals, then resolves **one explainable control decision per evaluation cycle**.
 
-it give you:
+It gives you:
 
 - season-aware humidity targets
 - deterministic lane priority
@@ -56,7 +56,7 @@ Current release: **v2.0.5**.
 
 ## What Is Humidity Intelligence
 
-Humidity Intelligence is designed to help stabilise the environment inside a home using real-world sensor telemetry and smart environmental control.
+Humidity Intelligence is designed to help stabilise the environment inside a home through real-world sensor telemetry, deterministic control, and practical environmental balancing.
 
 Rather than simply displaying humidity or temperature readings, Humidity Intelligence continuously interprets conditions across the property to understand how the environment is behaving over time. It monitors factors such as humidity, temperature, temperature drift, air quality, condensation risk, mould risk, and seasonal comfort patterns, then reacts using connected smart devices to gently guide the home back toward balance.
 
@@ -217,9 +217,9 @@ Default temperature comfort bands:
 
 Humidity Intelligence is built around a simple premise: a home should not be regulated by a loose pile of automations competing for control. It should have one visible environmental controller that reads configured telemetry, applies a stable priority hierarchy, and resolves one explainable outcome per evaluation cycle.
 
-The engine is deterministic by design. Avoids guesses, and learns hidden preferences. It evaluates season-aware humidity targets, safety gates, alert conditions, zone demand, air quality state, and humidifier needs through explicit rules so runtime behavior can be inspected, predicted, and explained.
+The engine is deterministic by design. It does not guess, learn hidden preferences, or invent state. It evaluates season-aware humidity targets, safety gates, alert conditions, zone demand, air quality state, and humidifier needs through explicit rules so runtime behavior can be inspected, anticipated, and explained.
 
-The UI is a truth surface. Current Air Control, chips, diagnostics, and exported cards  reflect backend telemetry, entity mappings, runtime mode, and degraded-state reasons. If an input is missing or an output is unavailable, Humidity Intelligence show that condition and fall back safely without pretending the home is stable.
+The UI is a truth surface, not a second controller. Current Air Control, chips, diagnostics, and exported cards reflect backend telemetry, entity mappings, runtime mode, and degraded-state reasons. If an input is missing or an output is unavailable, Humidity Intelligence shows that condition and falls back safely without pretending the home is stable.
 
 The architectural preference is calm regulation over automation chaos:
 
@@ -230,7 +230,7 @@ The architectural preference is calm regulation over automation chaos:
 - generated dashboards aligned with backend truth only
 - safe degraded behavior before blind output writes
 
-The result  feel steady in a domestic environment: readable, conservative, and accountable when conditions change.
+The result should feel steady in a domestic environment: readable, conservative, and accountable when conditions change.
 
 ---
 
@@ -310,13 +310,13 @@ The UI renders.
 
 ## Current Release Highlights
 
-- setup and options now present essentials first, with tuning controls behind Advanced sections that open/retract immediately within the form
-- HI applies recommended defaults unless you customise them 
+- setup and options now present essentials first, with tuning controls behind Advanced sections that open/retract immediately in the form
+- HI applies recommended defaults unless you customise them
 - control loop interval, startup UI mapping refresh, custom humidity targets, custom temperature comfort values, slope sources, fan levels, threshold tuning, lane removal, AQ tuning, and visual-alert tuning remain available as advanced controls
 - new installs default the generated V2 dashboard to a cleaner output display
 - `Show output entity details` can re-enable the generated-card output details panel when deeper runtime inspection is useful
 - `v2_tablet` is selected by default during initial UI export; unscoped `dump_cards` still exports all cached/generated layouts unless `layout` is supplied
-- native diagnostics, issue-template triage, house humidity drift dependency reporting, seeded slope startup state, and registered slope mapping improve supportability without adding hidden control paths
+- native Home Assistant diagnostics, issue-template triage, house humidity drift dependency reporting, seeded slope startup state, and registered slope mapping improve supportability without adding hidden control paths
 - deterministic runtime lane ordering, alert hierarchy, CO emergency behavior, humidifier independence, entity names, and `dump_cards` remain unchanged
 
 Upgrade note: **v2.0.5 concentrates on configuration UX, generated-card visibility, diagnostics, issue support, drift dependency reporting, and slope mapping correctness.** The control engine semantics remain stable.

--- a/docs/issue-triage.md
+++ b/docs/issue-triage.md
@@ -4,7 +4,7 @@ Humidity Intelligence includes a report-only Codex workspace helper for daily Gi
 issue triage.
 
 The helper fetches open GitHub issues, identifies new, untriaged, or recently updated
-items, and writes a structured Markdown report for Bella, Aetherwing, Aethermite, or
+items, and writes a structured Markdown report for Bella, Aetherwing, Aetherbite, or
 the human maintainer to review.
 
 It does not close, edit, label, assign, or comment on GitHub issues.
@@ -25,6 +25,10 @@ Default output:
 
 `.codex/` is local workspace output. Keep generated triage reports ignored/local unless
 the maintainer explicitly asks to publish a sanitized summary.
+
+Generated triage reports are timestamped support snapshots. They do not override the
+current release state recorded in `CHANGELOG.md`, `ROADMAP.md`, or
+`docs/release-governance.md`.
 
 ## Authentication
 
@@ -82,7 +86,7 @@ Suggested owner mapping:
 
 - Bella: architecture, roadmap, governance, proposals, coherence, documentation truth
 - Aetherwing: runtime safety, regression protection, release validation, deterministic lane logic, issue fixes
-- Aethermite: UI ideas, visual polish, brainstorms, experimental UX proposals
+- Aetherbite: UI ideas, visual polish, brainstorms, experimental UX proposals
 - Human maintainer/Jules: unclear reports, repo policy decisions, community-facing replies, release approval
 
 Priority mapping:

--- a/docs/release-governance.md
+++ b/docs/release-governance.md
@@ -12,6 +12,9 @@ testing and validation branches.
 The integration version in `manifest.json` is the release-state source of truth for
 Home Assistant and HACS metadata checks.
 
+v2.0.5 is a completed stable release milestone. The rules below remain the active
+promotion model for future versions and for any v2.0.5 maintenance patch.
+
 ## Branch Responsibilities
 
 - `senyo888-patch-1`: staging lane for all manifest labels. It may carry beta, rc,
@@ -51,8 +54,9 @@ until all of these gates are satisfied:
   direct sanity, service, or generated-card checks.
 - The README has maintainer approval before release tagging.
 
-If any gate is missing, the release state is `not ready`, even when the manifest version
-already carries a stable number on `senyo888-patch-1`, `develop`, or `main`.
+If any gate is missing for the version being prepared, the release state is `not ready`,
+even when the manifest version already carries a stable number on `senyo888-patch-1`,
+`develop`, or `main`.
 
 ## Enforcement
 

--- a/docs/support.md
+++ b/docs/support.md
@@ -1,6 +1,6 @@
 # Support and Diagnostics
 
-Use Home Assistant's native diagnostics download when reporting a Humidity Intelligence issue.
+Use Home Assistant's native diagnostics download when reporting a Humidity Intelligence issue. This is the preferred GitHub support bundle for v2.0.5 and later.
 
 ## Download Diagnostics
 
@@ -59,4 +59,4 @@ Open the issue anyway and fill in the fallback fields:
 
 ## Maintainer Notes
 
-Native diagnostics are the preferred GitHub attachment. The existing `humidity_intelligence.dump_diagnostics` service remains useful for local Home Assistant validation and writes a fuller JSON export to `/config`, but users should attach the native Home Assistant diagnostics download unless asked otherwise.
+Native diagnostics are the preferred GitHub attachment. The existing `humidity_intelligence.dump_diagnostics` service remains useful for local Home Assistant validation and writes a fuller JSON export to `/config`, but users should attach the native Home Assistant diagnostics download unless asked otherwise. Review any full `dump_diagnostics` export before sharing it publicly because it intentionally contains more local troubleshooting context than the native issue bundle.

--- a/services.py
+++ b/services.py
@@ -44,6 +44,9 @@ _FLASH_LIGHT_LOCKS_KEY = "_flash_light_locks"
 _ALLOWED_LAYOUTS = {"v2_mobile", "v2_tablet", "v1_mobile", "view_cards_button"}
 _SAFE_FILENAME_RE = re.compile(r"^[A-Za-z0-9._-]{1,128}$")
 _SAFE_DASHBOARD_PATH_RE = re.compile(r"^[a-z0-9_-]{1,64}$")
+_V205_RELEASE_CHECK_COMPATIBLE_VERSION_RE = re.compile(
+    r"^2\.0\.(?:5|6(?:-(?:beta|rc)\.[1-9]\d*)?)$"
+)
 _SENSITIVE_ATTR_EXACT = {
     "access_token",
     "token",
@@ -779,12 +782,13 @@ def _build_v205_release_check_entry_report(
     entity_map = runtime_data.get("entity_map", {}) or {}
     effective = _effective_entry_config(entry)
     checks: List[Dict[str, Any]] = []
+    manifest_status, manifest_message = _v205_release_check_manifest_status(manifest_version)
 
     _add_check(
         checks,
         "manifest_version",
-        "pass" if manifest_version == "2.0.5" else "fail",
-        f"Manifest version is {manifest_version or 'unknown'}; expected 2.0.5.",
+        manifest_status,
+        manifest_message,
     )
 
     show_output_details = bool(
@@ -903,6 +907,19 @@ def _build_v205_release_check_entry_report(
         "entry_id": getattr(entry, "entry_id", None),
         "checks": checks,
     }
+
+
+def _v205_release_check_manifest_status(manifest_version: Optional[str]) -> Tuple[str, str]:
+    version = manifest_version or "unknown"
+    if manifest_version and _V205_RELEASE_CHECK_COMPATIBLE_VERSION_RE.fullmatch(manifest_version):
+        return (
+            "pass",
+            f"Manifest version is {version}; v205_release_check is compatible with the v2.0.5/v2.0.6 maintenance line.",
+        )
+    return (
+        "fail",
+        f"Manifest version is {version}; expected 2.0.5 or a v2.0.6 beta/rc/stable version.",
+    )
 
 
 def _effective_entry_config(entry: Any) -> dict:

--- a/services.yaml
+++ b/services.yaml
@@ -74,7 +74,7 @@ self_check:
         text: {}
 v205_release_check:
   name: v2.0.5 Release Check
-  description: Run a read-only v2.0.5 validation report for generated-card visibility, dump_cards scope behavior, cached layouts, unresolved placeholders, frontend dependency status, house humidity drift dependency status, and configured entity availability.
+  description: Run a read-only v2.0.5/v2.0.6 maintenance-line validation report for generated-card visibility, dump_cards scope behavior, cached layouts, unresolved placeholders, frontend dependency status, house humidity drift dependency status, and configured entity availability. The service name remains v205_release_check for compatibility.
   fields:
     entry_id:
       name: Entry ID

--- a/tests 2/test_runtime_card_sanity.py
+++ b/tests 2/test_runtime_card_sanity.py
@@ -2373,6 +2373,20 @@ def test_v205_release_check_report_verifies_export_contract_and_ui_visibility():
     assert checks["generated_cards_text_sanity"]["status"] == "pass"
     assert checks["frontend_dependencies_reported"]["status"] == "pass"
 
+    beta_report = services_mod._build_v205_release_check_entry_report(
+        hass,
+        entry,
+        runtime_data,
+        manifest_version="2.0.6-beta.1",
+        frontend_dependencies={
+            "status": "not_inspectable",
+            "reason": "Lovelace resource collection is not available in this Home Assistant runtime context.",
+        },
+    )
+    beta_checks = {check["id"]: check for check in beta_report["checks"]}
+    assert beta_report["status"] == "pass"
+    assert beta_checks["manifest_version"]["status"] == "pass"
+
     failed_report = services_mod._build_v205_release_check_entry_report(
         hass,
         entry,


### PR DESCRIPTION
## Summary

<!-- Validation cl -->

## Type

- [ ] Fix
- [ ] Feature
- [x] Documentation
- [ ] UI Gallery
- [ ] Maintenance

## Checks

- [ ] PR targets `develop`.
- [ ] Tested in Home Assistant, or testing notes explain why not.
- [ ] Restart/config flow checked where relevant.
- [ ] Ran `humidity_intelligence.refresh_ui` or refreshed dashboards where UI output changed.
- [ ] Docs/changelog updated where needed.
- [ ] Support docs, diagnostics guidance, and issue templates updated where support flow changed.
- [ ] No private entity IDs, secrets, addresses, or personal data included.
- [ ] HACS/custom integration metadata still looks correct.

## UI Gallery submissions

- [ ] Uses `/ui-gallery/<card-id>/`.
- [ ] Includes `README.md`, `preview.png`, and `card.yaml` or `dashboard.yaml`.
- [ ] Top-level `ui-gallery/README.md` is updated.
- [ ] Example follows `ui-gallery/reference.txt` format.
- [ ] Required custom cards are documented.
- [ ] Preserves canonical Humidity Intelligence backend entities/helpers.
- [ ] Screenshots and YAML contain no private entity IDs, secrets, addresses, device IDs, tokens, internal URLs, or personal data.
