### PR TITLE
fix: harden config flow navigation and zone trigger labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ This project follows a practical changelog format for Home Assistant and HACS us
 
 ## Unreleased
 
-No changes yet.
+- Fixed setup/options telemetry add and edit pages so users can cancel back to the previous telemetry page without losing already-saved flow data, with explicit close-without-saving confirmation on HI-controlled Cancel actions.
+- Fixed Zone 2 setup/options defaults and trigger labels so Zone 2 trigger ownership is shown and stored as Zone 2 / Level 2 unless explicitly changed.
 
 ## 2.0.5
 

--- a/config_flow.py
+++ b/config_flow.py
@@ -83,6 +83,10 @@ ADVANCED_OPTIONS_FIELD = "show_advanced_options"
 ADVANCED_DEFAULTS_NOTE = (
     "Humidity Intelligence applies recommended defaults unless you customise these settings."
 )
+FORM_ACTION_SAVE = "save"
+FORM_ACTION_CANCEL = "cancel"
+FORM_ACTION_RETURN = "return"
+FORM_ACTION_CLOSE = "close"
 
 
 def _advanced_section(fields: Dict[Any, Any]) -> Any:
@@ -105,6 +109,20 @@ def _form_input_default(user_input: Optional[Dict[str, Any]], field: str, defaul
     if isinstance(user_input, dict):
         return user_input.get(field, default)
     return default
+
+
+def _save_cancel_options(save_label: str) -> List[SelectOptionDict]:
+    return [
+        SelectOptionDict(value=FORM_ACTION_SAVE, label=save_label),
+        SelectOptionDict(value=FORM_ACTION_CANCEL, label="Cancel"),
+    ]
+
+
+def _cancel_confirm_options(return_label: str) -> List[SelectOptionDict]:
+    return [
+        SelectOptionDict(value=FORM_ACTION_RETURN, label=return_label),
+        SelectOptionDict(value=FORM_ACTION_CLOSE, label="Close without saving"),
+    ]
 
 
 def _configured_zone_items(zones: Dict[str, Any]) -> List[Tuple[str, Dict[str, Any]]]:
@@ -137,6 +155,7 @@ class HumidityIntelligenceConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self._alerts: List[Dict[str, Any]] = []
         self._pending_zone_key: Optional[str] = None
         self._pending_aq_level: Optional[str] = None
+        self._cancel_return_step = "telemetry"
 
     async def async_step_user(self, user_input: Optional[Dict[str, Any]] = None):
         """Entry point for the flow. Present the frontend dependencies page first."""
@@ -426,36 +445,51 @@ class HumidityIntelligenceConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Add a telemetry sensor entry."""
         errors: Dict[str, str] = {}
         if user_input is not None:
-            entity_id = user_input["entity_id"]
-            if any(t.get("entity_id") == entity_id for t in self._telemetry):
+            action = user_input.get("action", FORM_ACTION_SAVE)
+            if action == FORM_ACTION_CANCEL:
+                return await self._async_show_cancel_confirm("telemetry")
+
+            entity_id = _sanitize_optional_entity_id(user_input.get("entity_id"))
+            if not entity_id:
+                errors["entity_id"] = "required"
+            elif any(t.get("entity_id") == entity_id for t in self._telemetry):
                 errors["entity_id"] = "duplicate_entity"
             else:
                 entry = {
                     "entity_id": entity_id,
-                    "sensor_type": user_input["sensor_type"],
+                    "sensor_type": user_input.get("sensor_type", SENSOR_TYPES[0]["value"]),
                     "friendly_name": user_input.get("friendly_name", ""),
-                    "level": user_input["level"],
+                    "level": user_input.get("level", LEVELS[0]["value"]),
                     "room": user_input.get("room", ""),
                 }
                 self._telemetry.append(entry)
                 self._data["telemetry"] = self._telemetry
                 return await self.async_step_telemetry()
 
-        default_room, default_level = _suggest_room_and_level(self.hass, user_input["entity_id"] if user_input else None)
+        default_room, default_level = _suggest_room_and_level(
+            self.hass,
+            _sanitize_optional_entity_id(user_input.get("entity_id")) if user_input else None,
+        )
         room_options = [SelectOptionDict(value=o, label=o) for o in COMMON_ROOMS]
         level_default = default_level or LEVELS[0]["value"]
         schema = vol.Schema({
-            vol.Required("entity_id"): selector.EntitySelector(
+            vol.Optional("action", default=FORM_ACTION_SAVE): selector.SelectSelector(
+                selector.SelectSelectorConfig(
+                    options=_save_cancel_options("Save sensor"),
+                    mode=selector.SelectSelectorMode.DROPDOWN,
+                )
+            ),
+            vol.Optional("entity_id"): selector.EntitySelector(
                 selector.EntitySelectorConfig(domain="sensor", multiple=False)
             ),
-            vol.Required("sensor_type", default=SENSOR_TYPES[0]["value"]): selector.SelectSelector(
+            vol.Optional("sensor_type", default=SENSOR_TYPES[0]["value"]): selector.SelectSelector(
                 selector.SelectSelectorConfig(
                     options=[SelectOptionDict(value=o["value"], label=o["label"]) for o in SENSOR_TYPES],
                     mode=selector.SelectSelectorMode.DROPDOWN,
                 )
             ),
             vol.Optional("friendly_name", default=""): selector.TextSelector(),
-            vol.Required("level", default=level_default): selector.SelectSelector(
+            vol.Optional("level", default=level_default): selector.SelectSelector(
                 selector.SelectSelectorConfig(
                     options=[SelectOptionDict(value=o["value"], label=o["label"]) for o in LEVELS],
                     mode=selector.SelectSelectorMode.DROPDOWN,
@@ -488,6 +522,28 @@ class HumidityIntelligenceConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_telemetry_back(self, user_input: Optional[Dict[str, Any]] = None):
         return await self.async_step_gates()
 
+    async def _async_show_cancel_confirm(self, return_step: str = "telemetry"):
+        self._cancel_return_step = return_step
+        return await self.async_step_cancel_confirm()
+
+    async def async_step_cancel_confirm(self, user_input: Optional[Dict[str, Any]] = None):
+        """Confirm closing a setup flow that has unsaved progress."""
+        if user_input is not None:
+            action = user_input.get("action", FORM_ACTION_RETURN)
+            if action == FORM_ACTION_CLOSE:
+                return self.async_abort(reason="user_cancelled")
+            return await self.async_step_telemetry()
+
+        schema = vol.Schema({
+            vol.Required("action", default=FORM_ACTION_RETURN): selector.SelectSelector(
+                selector.SelectSelectorConfig(
+                    options=_cancel_confirm_options("Cancel close / return to setup"),
+                    mode=selector.SelectSelectorMode.DROPDOWN,
+                )
+            ),
+        })
+        return self.async_show_form(step_id="cancel_confirm", data_schema=schema)
+
     async def async_step_telemetry_manage(self, user_input: Optional[Dict[str, Any]] = None):
         """Edit or delete an existing telemetry entry."""
         if not self._telemetry:
@@ -497,6 +553,8 @@ class HumidityIntelligenceConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             selection = user_input.get("selection")
             action = user_input.get("action")
+            if action == FORM_ACTION_CANCEL:
+                return await self._async_show_cancel_confirm("telemetry")
             if selection is None:
                 errors["selection"] = "required"
             else:
@@ -523,6 +581,7 @@ class HumidityIntelligenceConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     options=[
                         SelectOptionDict(value="edit", label="Edit"),
                         SelectOptionDict(value="delete", label="Delete"),
+                        SelectOptionDict(value=FORM_ACTION_CANCEL, label="Cancel"),
                     ],
                     mode=selector.SelectSelectorMode.DROPDOWN,
                 )
@@ -546,15 +605,21 @@ class HumidityIntelligenceConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         current = self._telemetry[index]
         errors: Dict[str, str] = {}
         if user_input is not None:
-            entity_id = user_input["entity_id"]
-            if any(i != index and t.get("entity_id") == entity_id for i, t in enumerate(self._telemetry)):
+            action = user_input.get("action", FORM_ACTION_SAVE)
+            if action == FORM_ACTION_CANCEL:
+                return await self._async_show_cancel_confirm("telemetry")
+
+            entity_id = _sanitize_optional_entity_id(user_input.get("entity_id"))
+            if not entity_id:
+                errors["entity_id"] = "required"
+            elif any(i != index and t.get("entity_id") == entity_id for i, t in enumerate(self._telemetry)):
                 errors["entity_id"] = "duplicate_entity"
             else:
                 current.update({
                     "entity_id": entity_id,
-                    "sensor_type": user_input["sensor_type"],
+                    "sensor_type": user_input.get("sensor_type", current.get("sensor_type", SENSOR_TYPES[0]["value"])),
                     "friendly_name": user_input.get("friendly_name", ""),
-                    "level": user_input["level"],
+                    "level": user_input.get("level", current.get("level", LEVELS[0]["value"])),
                     "room": user_input.get("room", ""),
                 })
                 self._telemetry[index] = current
@@ -563,17 +628,23 @@ class HumidityIntelligenceConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         room_options = [SelectOptionDict(value=o, label=o) for o in COMMON_ROOMS]
         schema = vol.Schema({
-            vol.Required("entity_id", default=current.get("entity_id")): selector.EntitySelector(
+            vol.Optional("action", default=FORM_ACTION_SAVE): selector.SelectSelector(
+                selector.SelectSelectorConfig(
+                    options=_save_cancel_options("Save sensor"),
+                    mode=selector.SelectSelectorMode.DROPDOWN,
+                )
+            ),
+            vol.Optional("entity_id", default=current.get("entity_id")): selector.EntitySelector(
                 selector.EntitySelectorConfig(domain="sensor", multiple=False)
             ),
-            vol.Required("sensor_type", default=current.get("sensor_type")): selector.SelectSelector(
+            vol.Optional("sensor_type", default=current.get("sensor_type")): selector.SelectSelector(
                 selector.SelectSelectorConfig(
                     options=[SelectOptionDict(value=o["value"], label=o["label"]) for o in SENSOR_TYPES],
                     mode=selector.SelectSelectorMode.DROPDOWN,
                 )
             ),
             vol.Optional("friendly_name", default=current.get("friendly_name", "")): selector.TextSelector(),
-            vol.Required("level", default=current.get("level")): selector.SelectSelector(
+            vol.Optional("level", default=current.get("level")): selector.SelectSelector(
                 selector.SelectSelectorConfig(
                     options=[SelectOptionDict(value=o["value"], label=o["label"]) for o in LEVELS],
                     mode=selector.SelectSelectorMode.DROPDOWN,
@@ -698,7 +769,7 @@ class HumidityIntelligenceConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             enabled = user_input.get("enabled", False)
             zone = {
                 "enabled": enabled,
-                "level": user_input.get("level"),
+                "level": user_input.get("level") or existing.get("level") or _default_zone_level(zone_key),
                 "rooms": user_input.get("rooms", []),
                 "triggers": user_input.get("triggers", []),
                 "outputs": user_input.get("outputs", []),
@@ -734,11 +805,11 @@ class HumidityIntelligenceConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             return await self.async_step_zones()
 
         rooms_all = _rooms_all(self._telemetry)
-        level_default = existing.get("level") or LEVELS[0]["value"]
+        level_default = existing.get("level") or _default_zone_level(zone_key)
         room_options = [SelectOptionDict(value=r, label=r) for r in rooms_all]
         zone_default = lambda field, default: _form_input_default(user_input, field, default)
         selected_level_default = zone_default("level", level_default)
-        trigger_options = _zone_trigger_options(selected_level_default)
+        trigger_options = _zone_trigger_options(selected_level_default, zone_key)
         schema_fields: Dict[Any, Any] = {
             vol.Optional("enabled", default=zone_default("enabled", existing.get("enabled", False))): selector.BooleanSelector(),
             vol.Optional("level", default=selected_level_default): selector.SelectSelector(
@@ -1326,6 +1397,7 @@ class HumidityIntelligenceOptionsFlow(config_entries.OptionsFlow):
         self._pending_aq_level: Optional[str] = None
         self._pending_alert_index: Optional[int] = None
         self._pending_presence_gate: Optional[Dict[str, Any]] = None
+        self._cancel_return_step = "options_telemetry"
 
     def _section(self, key: str, default: Any) -> Any:
         if key in self._options:
@@ -1337,6 +1409,28 @@ class HumidityIntelligenceOptionsFlow(config_entries.OptionsFlow):
         config.update(dict(getattr(self._entry, "options", None) or {}))
         config.update(dict(self._options))
         return config
+
+    async def _async_show_options_cancel_confirm(self, return_step: str = "options_telemetry"):
+        self._cancel_return_step = return_step
+        return await self.async_step_options_cancel_confirm()
+
+    async def async_step_options_cancel_confirm(self, user_input: Optional[Dict[str, Any]] = None):
+        """Confirm closing an options flow with unsaved changes."""
+        if user_input is not None:
+            action = user_input.get("action", FORM_ACTION_RETURN)
+            if action == FORM_ACTION_CLOSE:
+                return self.async_abort(reason="user_cancelled")
+            return await self.async_step_options_telemetry()
+
+        schema = vol.Schema({
+            vol.Required("action", default=FORM_ACTION_RETURN): selector.SelectSelector(
+                selector.SelectSelectorConfig(
+                    options=_cancel_confirm_options("Cancel close / return to options"),
+                    mode=selector.SelectSelectorMode.DROPDOWN,
+                )
+            ),
+        })
+        return self.async_show_form(step_id="options_cancel_confirm", data_schema=schema)
 
     def _sync_slope_after_telemetry_add(self, telemetry_entry: Dict[str, Any]) -> None:
         """Keep slope source associations in sync when adding temperature telemetry."""
@@ -1866,6 +1960,10 @@ class HumidityIntelligenceOptionsFlow(config_entries.OptionsFlow):
         errors: Dict[str, str] = {}
 
         if user_input is not None:
+            action = user_input.get("action", FORM_ACTION_SAVE)
+            if action == FORM_ACTION_CANCEL:
+                return await self._async_show_options_cancel_confirm("options_telemetry")
+
             entity_id = _sanitize_optional_entity_id(user_input.get("entity_id"))
             if not entity_id:
                 errors["entity_id"] = "required"
@@ -1896,10 +1994,16 @@ class HumidityIntelligenceOptionsFlow(config_entries.OptionsFlow):
         room_options = [SelectOptionDict(value=o, label=o) for o in COMMON_ROOMS]
         level_default = default_level or LEVELS[0]["value"]
         schema = vol.Schema({
-            vol.Required("entity_id"): selector.EntitySelector(
+            vol.Optional("action", default=FORM_ACTION_SAVE): selector.SelectSelector(
+                selector.SelectSelectorConfig(
+                    options=_save_cancel_options("Save sensor"),
+                    mode=selector.SelectSelectorMode.DROPDOWN,
+                )
+            ),
+            vol.Optional("entity_id"): selector.EntitySelector(
                 selector.EntitySelectorConfig(domain="sensor", multiple=False)
             ),
-            vol.Required("sensor_type", default=SENSOR_TYPES[0]["value"]): selector.SelectSelector(
+            vol.Optional("sensor_type", default=SENSOR_TYPES[0]["value"]): selector.SelectSelector(
                 selector.SelectSelectorConfig(
                     options=[SelectOptionDict(value=o["value"], label=o["label"]) for o in SENSOR_TYPES],
                     mode=selector.SelectSelectorMode.DROPDOWN,
@@ -1908,7 +2012,7 @@ class HumidityIntelligenceOptionsFlow(config_entries.OptionsFlow):
             vol.Optional("friendly_name", default=""): selector.TextSelector(
                 selector.TextSelectorConfig(type=selector.TextSelectorType.TEXT)
             ),
-            vol.Required("level", default=level_default): selector.SelectSelector(
+            vol.Optional("level", default=level_default): selector.SelectSelector(
                 selector.SelectSelectorConfig(
                     options=[SelectOptionDict(value=o["value"], label=o["label"]) for o in LEVELS],
                     mode=selector.SelectSelectorMode.DROPDOWN,
@@ -1940,6 +2044,8 @@ class HumidityIntelligenceOptionsFlow(config_entries.OptionsFlow):
         if user_input is not None:
             selection = user_input.get("selection")
             action = user_input.get("action")
+            if action == FORM_ACTION_CANCEL:
+                return await self._async_show_options_cancel_confirm("options_telemetry")
             try:
                 idx = int(selection)
             except (TypeError, ValueError):
@@ -1973,6 +2079,7 @@ class HumidityIntelligenceOptionsFlow(config_entries.OptionsFlow):
                     options=[
                         SelectOptionDict(value="edit", label="Edit"),
                         SelectOptionDict(value="delete", label="Delete"),
+                        SelectOptionDict(value=FORM_ACTION_CANCEL, label="Cancel"),
                     ],
                     mode=selector.SelectSelectorMode.DROPDOWN,
                 )
@@ -1996,6 +2103,10 @@ class HumidityIntelligenceOptionsFlow(config_entries.OptionsFlow):
         errors: Dict[str, str] = {}
 
         if user_input is not None:
+            action = user_input.get("action", FORM_ACTION_SAVE)
+            if action == FORM_ACTION_CANCEL:
+                return await self._async_show_options_cancel_confirm("options_telemetry")
+
             selected_entity = _sanitize_optional_entity_id(user_input.get("entity_id"))
             if selected_entity and any(i != idx and item.get("entity_id") == selected_entity for i, item in enumerate(telemetry)):
                 errors["entity_id"] = "duplicate_entity"
@@ -2020,6 +2131,12 @@ class HumidityIntelligenceOptionsFlow(config_entries.OptionsFlow):
         sensor_type_options = [SelectOptionDict(value=o["value"], label=o["label"]) for o in SENSOR_TYPES]
         entity_default = _sanitize_optional_entity_id(current.get("entity_id"))
         schema = vol.Schema({
+            vol.Optional("action", default=FORM_ACTION_SAVE): selector.SelectSelector(
+                selector.SelectSelectorConfig(
+                    options=_save_cancel_options("Save sensor"),
+                    mode=selector.SelectSelectorMode.DROPDOWN,
+                )
+            ),
             vol.Optional("entity_id", default=entity_default): selector.EntitySelector(
                 selector.EntitySelectorConfig(domain="sensor", multiple=False)
             ),
@@ -2085,8 +2202,7 @@ class HumidityIntelligenceOptionsFlow(config_entries.OptionsFlow):
     async def async_step_options_zone_edit(self, user_input: Optional[Dict[str, Any]] = None):
         zones = dict(self._section("zones", {}))
         zone_key = self._pending_zone_key or "zone1"
-        configured_levels = _configured_levels(self._section("telemetry", []))
-        default_level = configured_levels[0] if configured_levels else LEVELS[0]["value"]
+        default_level = _default_zone_level(zone_key)
         zone = zones.get(zone_key) or {
             "enabled": False,
             "level": default_level,
@@ -2119,7 +2235,7 @@ class HumidityIntelligenceOptionsFlow(config_entries.OptionsFlow):
             zones[zone_key] = {
                 **zone,
                 "enabled": user_input.get("enabled", zone.get("enabled", True)),
-                "level": user_input.get("level", zone.get("level")),
+                "level": user_input.get("level") or zone.get("level") or _default_zone_level(zone_key),
                 "rooms": user_input.get("rooms", zone.get("rooms", [])),
                 "triggers": selected_triggers,
                 "outputs": _sanitize_entity_ids(user_input.get("outputs", zone.get("outputs", []))),
@@ -2175,7 +2291,7 @@ class HumidityIntelligenceOptionsFlow(config_entries.OptionsFlow):
             ),
             vol.Optional("triggers", default=zone_default("triggers", selected_triggers)): selector.SelectSelector(
                 selector.SelectSelectorConfig(
-                    options=_zone_trigger_options(selected_level_default),
+                    options=_zone_trigger_options(selected_level_default, zone_key),
                     multiple=True,
                     mode=selector.SelectSelectorMode.DROPDOWN,
                 )
@@ -3388,11 +3504,25 @@ def _telemetry_label(item: Dict[str, Any]) -> str:
 
 
 def _zone_choice_label(zone_key: str, zone: Dict[str, Any]) -> str:
-    title = "Zone 1" if zone_key == "zone1" else "Zone 2"
+    title = _zone_title(zone_key)
     level = _level_choice_label(zone.get("level"))
     enabled = "Enabled" if zone.get("enabled") else "Disabled"
     ui_label = _sanitize_ui_label(zone.get("ui_label"), _default_zone_ui_label(zone_key))
     return f"{title} - {enabled} ({level}, UI label: {ui_label})"
+
+
+def _zone_title(zone_key: str) -> str:
+    if zone_key == "zone1":
+        return "Zone 1"
+    if zone_key == "zone2":
+        return "Zone 2"
+    return str(zone_key or "Zone")
+
+
+def _default_zone_level(zone_key: str) -> str:
+    if zone_key == "zone2":
+        return "level2"
+    return "level1"
 
 
 def _level_choice_label(level: Optional[str]) -> str:
@@ -3475,10 +3605,17 @@ def _levels_with_aq(telemetry: List[Dict[str, Any]]) -> List[str]:
     return sorted(levels)
 
 
-def _zone_trigger_options(level: str) -> List[SelectOptionDict]:
+def _zone_trigger_context_label(level: str, zone_key: Optional[str]) -> str:
+    level_label = _level_choice_label(level)
+    if zone_key:
+        return f"{_zone_title(zone_key)} / {level_label}"
+    return level_label
+
+
+def _zone_trigger_options(level: str, zone_key: Optional[str] = None) -> List[SelectOptionDict]:
     opts = []
     for key, trig in TRIGGER_DEFS.items():
-        label = f"{trig['label']} ({level})"
+        label = f"{trig['label']} ({_zone_trigger_context_label(level, zone_key)})"
         opts.append(SelectOptionDict(value=key, label=label))
     return opts
 

--- a/strings.json
+++ b/strings.json
@@ -63,9 +63,10 @@
         }
       },
       "telemetry_add": {
-        "title": "Add Sensor",
-        "description": "Add a humidity, temperature or air-quality sensor.\n\nExisting sensors:\n{existing}",
+        "title": "Add Telemetry Sensor",
+        "description": "Add a humidity, temperature or air-quality sensor.\n\nExisting sensors:\n{existing}\n\nCancel returns to Telemetry Inputs without saving this sensor.",
         "data": {
+          "action": "Action",
           "entity_id": "Sensor entity",
           "sensor_type": "Sensor type",
           "friendly_name": "Friendly name (optional)",
@@ -74,7 +75,7 @@
         }
       },
       "telemetry_manage": {
-        "title": "Manage Sensors",
+        "title": "Manage Telemetry Sensors",
         "description": "Edit or delete an existing sensor.\n\nExisting sensors:\n{existing}",
         "data": {
           "selection": "Sensor",
@@ -82,14 +83,22 @@
         }
       },
       "telemetry_edit": {
-        "title": "Edit Sensor",
-        "description": "Update the selected sensor entry.",
+        "title": "Edit Telemetry Sensor",
+        "description": "Update the selected sensor entry.\n\nCancel returns to Telemetry Inputs without saving changes to this sensor.",
         "data": {
+          "action": "Action",
           "entity_id": "Sensor entity",
           "sensor_type": "Sensor type",
           "friendly_name": "Friendly name (optional)",
           "level": "Level",
           "room": "Room"
+        }
+      },
+      "cancel_confirm": {
+        "title": "Close Setup?",
+        "description": "This setup has not been saved. Closing will lose entered information.\n\nHome Assistant controls the top-left close button directly, so Humidity Intelligence can show this warning only from its own Cancel actions.",
+        "data": {
+          "action": "Action"
         }
       },
       "slope": {
@@ -396,10 +405,14 @@
     "error": {
       "overlap": "A state cannot be both present and away.",
       "duplicate_entity": "This sensor has already been added.",
+      "required": "This field is required.",
       "alert_save_failed": "Failed to save alert configuration. Check logs and try again.",
       "room_unknown": "Selected room is not in configured telemetry.",
       "room_missing_humidity": "Selected room has no humidity telemetry for room-scoped humidity danger.",
       "room_missing_temp_humidity": "Selected room needs both humidity and temperature telemetry for this room-scoped trigger."
+    },
+    "abort": {
+      "user_cancelled": "Setup closed without saving."
     }
   },
   "options": {
@@ -513,8 +526,9 @@
       },
       "options_telemetry_add": {
         "title": "Add Telemetry Sensor",
-        "description": "Add a sensor and knit it into HI telemetry.\n\nConfigured telemetry:\n{telemetry_summary}",
+        "description": "Add a sensor and knit it into HI telemetry.\n\nConfigured telemetry:\n{telemetry_summary}\n\nCancel returns to Telemetry Options without saving this sensor.",
         "data": {
+          "action": "Action",
           "entity_id": "Sensor entity",
           "sensor_type": "Sensor type",
           "friendly_name": "Friendly name (display only)",
@@ -532,13 +546,21 @@
       },
       "options_telemetry_edit": {
         "title": "Edit Telemetry Sensor",
-        "description": "Editing sensor {sensor_position} of {sensor_total}.\n\n{selected_sensor}",
+        "description": "Editing sensor {sensor_position} of {sensor_total}.\n\n{selected_sensor}\n\nCancel returns to Telemetry Options without saving changes to this sensor.",
         "data": {
+          "action": "Action",
           "entity_id": "Sensor entity",
           "sensor_type": "Sensor type",
           "friendly_name": "Friendly name (display only)",
           "level": "Level",
           "room": "Room"
+        }
+      },
+      "options_cancel_confirm": {
+        "title": "Close Options?",
+        "description": "These configuration changes have not been saved. Closing will lose entered information.\n\nHome Assistant controls the top-left close button directly, so Humidity Intelligence can show this warning only from its own Cancel actions.",
+        "data": {
+          "action": "Action"
         }
       },
       "options_zones": {
@@ -744,10 +766,14 @@
     "error": {
       "overlap": "A state cannot be both present and away.",
       "duplicate_entity": "This sensor has already been added.",
+      "required": "This field is required.",
       "alert_save_failed": "Failed to save alert configuration. Check logs and try again.",
       "room_unknown": "Selected room is not in configured telemetry.",
       "room_missing_humidity": "Selected room has no humidity telemetry for room-scoped humidity danger.",
       "room_missing_temp_humidity": "Selected room needs both humidity and temperature telemetry for this room-scoped trigger."
+    },
+    "abort": {
+      "user_cancelled": "Options closed without saving."
     }
   },
   "issues": {

--- a/tests 2/test_config_flow_sanity.py
+++ b/tests 2/test_config_flow_sanity.py
@@ -1,0 +1,397 @@
+"""Direct sanity checks for HI config/options-flow UX contracts."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import pathlib
+import sys
+import types
+from types import SimpleNamespace
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+PKG = "hi_config_flow_testpkg"
+
+
+def _install_homeassistant_stubs() -> None:
+    """Install lightweight Home Assistant stubs for config-flow imports."""
+    ha = types.ModuleType("homeassistant")
+    core = types.ModuleType("homeassistant.core")
+    config_entries = types.ModuleType("homeassistant.config_entries")
+    const = types.ModuleType("homeassistant.const")
+    components = types.ModuleType("homeassistant.components")
+    lovelace = types.ModuleType("homeassistant.components.lovelace")
+    data_entry_flow = types.ModuleType("homeassistant.data_entry_flow")
+    helpers = types.ModuleType("homeassistant.helpers")
+    area_registry = types.ModuleType("homeassistant.helpers.area_registry")
+    entity_registry = types.ModuleType("homeassistant.helpers.entity_registry")
+    selector = types.ModuleType("homeassistant.helpers.selector")
+    lovelace_const = types.ModuleType("homeassistant.components.lovelace.const")
+    voluptuous = types.ModuleType("voluptuous")
+
+    class HomeAssistant:
+        pass
+
+    class UnitOfTemperature:
+        CELSIUS = "degC"
+        FAHRENHEIT = "degF"
+
+    class ConfigEntry:
+        pass
+
+    class _BaseFlow:
+        def __init_subclass__(cls, **kwargs):
+            super().__init_subclass__()
+
+        def async_show_form(self, **kwargs):
+            return {"type": "form", **kwargs}
+
+        def async_show_menu(self, **kwargs):
+            return {"type": "menu", **kwargs}
+
+        def async_create_entry(self, **kwargs):
+            return {"type": "create_entry", **kwargs}
+
+        def async_abort(self, **kwargs):
+            return {"type": "abort", **kwargs}
+
+    class ConfigFlow(_BaseFlow):
+        async def async_set_unique_id(self, unique_id):
+            self._unique_id = unique_id
+
+        def _abort_if_unique_id_configured(self):
+            return None
+
+    class OptionsFlow(_BaseFlow):
+        pass
+
+    class _Registry:
+        def async_get(self, _key):
+            return None
+
+    class _SchemaKey:
+        def __init__(self, key, default=None):
+            self.key = key
+            self.default = default
+
+        def __hash__(self):
+            try:
+                return hash((self.key, self.default))
+            except TypeError:
+                return hash((self.key, repr(self.default)))
+
+        def __eq__(self, other):
+            return (
+                isinstance(other, _SchemaKey)
+                and self.key == other.key
+                and self.default == other.default
+            )
+
+    class Schema:
+        def __init__(self, schema):
+            self.schema = schema
+
+        def __call__(self, value):
+            return value
+
+    class SelectOptionDict(dict):
+        def __init__(self, *, value, label):
+            super().__init__(value=value, label=label)
+
+    class _SelectorConfig:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+    class _Selector:
+        def __init__(self, config=None):
+            self.config = config
+
+    def section(schema, options):
+        return {"schema": schema, "options": dict(options)}
+
+    core.HomeAssistant = HomeAssistant
+    const.UnitOfTemperature = UnitOfTemperature
+    config_entries.ConfigEntry = ConfigEntry
+    config_entries.ConfigFlow = ConfigFlow
+    config_entries.OptionsFlow = OptionsFlow
+    data_entry_flow.section = section
+    area_registry.async_get = lambda _hass: _Registry()
+    entity_registry.async_get = lambda _hass: _Registry()
+    lovelace_const.LOVELACE_DATA = "lovelace"
+
+    selector.SelectOptionDict = SelectOptionDict
+    selector.SelectSelector = _Selector
+    selector.SelectSelectorConfig = _SelectorConfig
+    selector.SelectSelectorMode = SimpleNamespace(DROPDOWN="dropdown")
+    selector.BooleanSelector = _Selector
+    selector.EntitySelector = _Selector
+    selector.EntitySelectorConfig = _SelectorConfig
+    selector.TextSelector = _Selector
+    selector.TextSelectorConfig = _SelectorConfig
+    selector.TextSelectorType = SimpleNamespace(TEXT="text")
+    selector.NumberSelector = _Selector
+    selector.NumberSelectorConfig = _SelectorConfig
+    selector.NumberSelectorMode = SimpleNamespace(SLIDER="slider", BOX="box")
+
+    voluptuous.Schema = Schema
+    voluptuous.Optional = _SchemaKey
+    voluptuous.Required = _SchemaKey
+
+    helpers.area_registry = area_registry
+    helpers.entity_registry = entity_registry
+    helpers.selector = selector
+
+    sys.modules["homeassistant"] = ha
+    sys.modules["homeassistant.core"] = core
+    sys.modules["homeassistant.config_entries"] = config_entries
+    sys.modules["homeassistant.const"] = const
+    sys.modules["homeassistant.components"] = components
+    sys.modules["homeassistant.components.lovelace"] = lovelace
+    sys.modules["homeassistant.data_entry_flow"] = data_entry_flow
+    sys.modules["homeassistant.helpers"] = helpers
+    sys.modules["homeassistant.helpers.area_registry"] = area_registry
+    sys.modules["homeassistant.helpers.entity_registry"] = entity_registry
+    sys.modules["homeassistant.helpers.selector"] = selector
+    sys.modules["homeassistant.components.lovelace.const"] = lovelace_const
+    sys.modules["voluptuous"] = voluptuous
+
+
+def _install_package_scaffold() -> None:
+    pkg = types.ModuleType(PKG)
+    pkg.__path__ = [str(ROOT)]
+    sys.modules[PKG] = pkg
+
+    helpers = types.ModuleType(f"{PKG}.helpers")
+    helpers.__path__ = [str(ROOT / "helpers")]
+    sys.modules[f"{PKG}.helpers"] = helpers
+
+
+def _load_module(name: str, path: pathlib.Path):
+    spec = importlib.util.spec_from_file_location(name, str(path))
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _load_config_flow_module():
+    _install_homeassistant_stubs()
+    _install_package_scaffold()
+    _load_module(f"{PKG}.const", ROOT / "const.py")
+    _load_module(f"{PKG}.helpers.parsing", ROOT / "helpers" / "parsing.py")
+    _load_module(f"{PKG}.helpers.drift", ROOT / "helpers" / "drift.py")
+    _load_module(
+        f"{PKG}.helpers.frontend_dependencies",
+        ROOT / "helpers" / "frontend_dependencies.py",
+    )
+    _load_module(
+        f"{PKG}.helpers.zone_validation",
+        ROOT / "helpers" / "zone_validation.py",
+    )
+    return _load_module(f"{PKG}.config_flow", ROOT / "config_flow.py")
+
+
+def _schema_default(result: dict, field: str):
+    for key in result["data_schema"].schema:
+        if getattr(key, "key", key) == field:
+            return getattr(key, "default", None)
+    raise AssertionError(f"{field!r} not present in schema")
+
+
+def _schema_select_values(result: dict, field: str):
+    for key, selector_obj in result["data_schema"].schema.items():
+        if getattr(key, "key", key) == field:
+            return [
+                option["value"]
+                for option in getattr(selector_obj.config, "options", [])
+            ]
+    raise AssertionError(f"{field!r} not present in schema")
+
+
+def _schema_select_labels(result: dict, field: str):
+    for key, selector_obj in result["data_schema"].schema.items():
+        if getattr(key, "key", key) == field:
+            return [
+                option["label"]
+                for option in getattr(selector_obj.config, "options", [])
+            ]
+    raise AssertionError(f"{field!r} not present in schema")
+
+
+def _option_labels(options):
+    return [option["label"] for option in options]
+
+
+def test_setup_add_sensor_cancel_requires_confirmation_and_preserves_entries():
+    config_flow = _load_config_flow_module()
+    flow = config_flow.HumidityIntelligenceConfigFlow()
+    flow.hass = SimpleNamespace()
+    existing = {
+        "entity_id": "sensor.kitchen_humidity",
+        "sensor_type": "humidity",
+        "friendly_name": "Kitchen",
+        "level": "level1",
+        "room": "Kitchen",
+    }
+    flow._telemetry = [dict(existing)]
+    flow._data["telemetry"] = flow._telemetry
+
+    result = asyncio.run(flow.async_step_telemetry_add({"action": "cancel"}))
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "cancel_confirm"
+    assert _schema_select_values(result, "action") == ["return", "close"]
+    assert _schema_select_labels(result, "action") == [
+        "Cancel close / return to setup",
+        "Close without saving",
+    ]
+
+    returned = asyncio.run(flow.async_step_cancel_confirm({"action": "return"}))
+
+    assert returned["type"] == "form"
+    assert returned["step_id"] == "telemetry"
+    assert flow._telemetry == [existing]
+    assert flow._data["telemetry"] == [existing]
+
+    closed = asyncio.run(flow.async_step_cancel_confirm({"action": "close"}))
+
+    assert closed["type"] == "abort"
+    assert closed["reason"] == "user_cancelled"
+
+
+def test_options_add_sensor_cancel_requires_confirmation_and_preserves_options():
+    config_flow = _load_config_flow_module()
+    existing = {
+        "entity_id": "sensor.kitchen_humidity",
+        "sensor_type": "humidity",
+        "friendly_name": "Kitchen",
+        "level": "level1",
+        "room": "Kitchen",
+    }
+    entry = SimpleNamespace(data={"telemetry": [dict(existing)]}, options={})
+    flow = config_flow.HumidityIntelligenceOptionsFlow(entry)
+    flow.hass = SimpleNamespace()
+
+    result = asyncio.run(flow.async_step_options_telemetry_add({"action": "cancel"}))
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "options_cancel_confirm"
+    assert _schema_select_values(result, "action") == ["return", "close"]
+    assert _schema_select_labels(result, "action") == [
+        "Cancel close / return to options",
+        "Close without saving",
+    ]
+
+    returned = asyncio.run(flow.async_step_options_cancel_confirm({"action": "return"}))
+
+    assert returned["type"] == "form"
+    assert returned["step_id"] == "options_telemetry"
+    assert flow._options == {}
+
+    closed = asyncio.run(flow.async_step_options_cancel_confirm({"action": "close"}))
+
+    assert closed["type"] == "abort"
+    assert closed["reason"] == "user_cancelled"
+
+
+def test_zone2_setup_defaults_to_level2_and_trigger_labels_name_zone_and_level():
+    config_flow = _load_config_flow_module()
+    flow = config_flow.HumidityIntelligenceConfigFlow()
+    flow.hass = SimpleNamespace()
+
+    result = asyncio.run(flow.async_step_zone2())
+    labels = _option_labels(config_flow._zone_trigger_options("level2", "zone2"))
+
+    assert _schema_default(result, "level") == "level2"
+    assert labels
+    assert all("(Zone 2 / Level 2" in label for label in labels)
+    assert all("Level 1" not in label for label in labels)
+
+
+def test_each_zone_exposes_both_level_choices_and_preserves_explicit_selection():
+    config_flow = _load_config_flow_module()
+    flow = config_flow.HumidityIntelligenceConfigFlow()
+    flow.hass = SimpleNamespace()
+
+    zone1_form = asyncio.run(flow.async_step_zone1())
+    zone2_form = asyncio.run(flow.async_step_zone2())
+    asyncio.run(
+        flow.async_step_zone1(
+            {
+                "enabled": True,
+                "level": "level2",
+                "rooms": [],
+                "triggers": [],
+                "outputs": [],
+            }
+        )
+    )
+    asyncio.run(
+        flow.async_step_zone2(
+            {
+                "enabled": True,
+                "level": "level1",
+                "rooms": [],
+                "triggers": [],
+                "outputs": [],
+            }
+        )
+    )
+
+    assert _schema_select_values(zone1_form, "level") == ["level1", "level2"]
+    assert _schema_select_values(zone2_form, "level") == ["level1", "level2"]
+    assert flow._data["zones"]["zone1"]["level"] == "level2"
+    assert flow._data["zones"]["zone2"]["level"] == "level1"
+
+
+def test_options_new_zone2_defaults_to_level2_and_preserves_trigger_ownership():
+    config_flow = _load_config_flow_module()
+    entry = SimpleNamespace(
+        data={
+            "telemetry": [
+                {
+                    "entity_id": "sensor.bedroom_humidity",
+                    "sensor_type": "humidity",
+                    "level": "level2",
+                    "room": "Bedroom",
+                }
+            ],
+            "zones": {},
+        },
+        options={},
+    )
+    flow = config_flow.HumidityIntelligenceOptionsFlow(entry)
+    flow.hass = SimpleNamespace()
+    flow._pending_zone_key = "zone2"
+
+    form = asyncio.run(flow.async_step_options_zone_edit())
+    labels = _option_labels(config_flow._zone_trigger_options("level2", "zone2"))
+    saved = asyncio.run(
+        flow.async_step_options_zone_edit(
+            {
+                "enabled": True,
+                "rooms": ["Bedroom"],
+                "triggers": ["humidity_high"],
+                "outputs": ["fan.zone2"],
+            }
+        )
+    )
+
+    assert _schema_default(form, "level") == "level2"
+    assert all("(Zone 2 / Level 2" in label for label in labels)
+    assert saved["step_id"] == "options_zones"
+    assert flow._options["zones"]["zone2"]["level"] == "level2"
+    assert flow._options["zones"]["zone2"]["triggers"] == ["humidity_high"]
+
+
+if __name__ == "__main__":
+    tests = [
+        (name, value)
+        for name, value in sorted(globals().items())
+        if name.startswith("test_") and callable(value)
+    ]
+    for name, test in tests:
+        test()
+    print(f"{len(tests)} config-flow sanity checks passed.")

--- a/translations/en.json
+++ b/translations/en.json
@@ -63,9 +63,10 @@
         }
       },
       "telemetry_add": {
-        "title": "Add Sensor",
-        "description": "Add a humidity, temperature or air-quality sensor.\n\nExisting sensors:\n{existing}",
+        "title": "Add Telemetry Sensor",
+        "description": "Add a humidity, temperature or air-quality sensor.\n\nExisting sensors:\n{existing}\n\nCancel returns to Telemetry Inputs without saving this sensor.",
         "data": {
+          "action": "Action",
           "entity_id": "Sensor entity",
           "sensor_type": "Sensor type",
           "friendly_name": "Friendly name (optional)",
@@ -74,7 +75,7 @@
         }
       },
       "telemetry_manage": {
-        "title": "Manage Sensors",
+        "title": "Manage Telemetry Sensors",
         "description": "Edit or delete an existing sensor.\n\nExisting sensors:\n{existing}",
         "data": {
           "selection": "Sensor",
@@ -82,14 +83,22 @@
         }
       },
       "telemetry_edit": {
-        "title": "Edit Sensor",
-        "description": "Update the selected sensor entry.",
+        "title": "Edit Telemetry Sensor",
+        "description": "Update the selected sensor entry.\n\nCancel returns to Telemetry Inputs without saving changes to this sensor.",
         "data": {
+          "action": "Action",
           "entity_id": "Sensor entity",
           "sensor_type": "Sensor type",
           "friendly_name": "Friendly name (optional)",
           "level": "Level",
           "room": "Room"
+        }
+      },
+      "cancel_confirm": {
+        "title": "Close Setup?",
+        "description": "This setup has not been saved. Closing will lose entered information.\n\nHome Assistant controls the top-left close button directly, so Humidity Intelligence can show this warning only from its own Cancel actions.",
+        "data": {
+          "action": "Action"
         }
       },
       "slope": {
@@ -396,10 +405,14 @@
     "error": {
       "overlap": "A state cannot be both present and away.",
       "duplicate_entity": "This sensor has already been added.",
+      "required": "This field is required.",
       "alert_save_failed": "Failed to save alert configuration. Check logs and try again.",
       "room_unknown": "Selected room is not in configured telemetry.",
       "room_missing_humidity": "Selected room has no humidity telemetry for room-scoped humidity danger.",
       "room_missing_temp_humidity": "Selected room needs both humidity and temperature telemetry for this room-scoped trigger."
+    },
+    "abort": {
+      "user_cancelled": "Setup closed without saving."
     }
   },
   "options": {
@@ -513,8 +526,9 @@
       },
       "options_telemetry_add": {
         "title": "Add Telemetry Sensor",
-        "description": "Add a sensor and knit it into HI telemetry.\n\nConfigured telemetry:\n{telemetry_summary}",
+        "description": "Add a sensor and knit it into HI telemetry.\n\nConfigured telemetry:\n{telemetry_summary}\n\nCancel returns to Telemetry Options without saving this sensor.",
         "data": {
+          "action": "Action",
           "entity_id": "Sensor entity",
           "sensor_type": "Sensor type",
           "friendly_name": "Friendly name (display only)",
@@ -532,13 +546,21 @@
       },
       "options_telemetry_edit": {
         "title": "Edit Telemetry Sensor",
-        "description": "Editing sensor {sensor_position} of {sensor_total}.\n\n{selected_sensor}",
+        "description": "Editing sensor {sensor_position} of {sensor_total}.\n\n{selected_sensor}\n\nCancel returns to Telemetry Options without saving changes to this sensor.",
         "data": {
+          "action": "Action",
           "entity_id": "Sensor entity",
           "sensor_type": "Sensor type",
           "friendly_name": "Friendly name (display only)",
           "level": "Level",
           "room": "Room"
+        }
+      },
+      "options_cancel_confirm": {
+        "title": "Close Options?",
+        "description": "These configuration changes have not been saved. Closing will lose entered information.\n\nHome Assistant controls the top-left close button directly, so Humidity Intelligence can show this warning only from its own Cancel actions.",
+        "data": {
+          "action": "Action"
         }
       },
       "options_zones": {
@@ -744,10 +766,14 @@
     "error": {
       "overlap": "A state cannot be both present and away.",
       "duplicate_entity": "This sensor has already been added.",
+      "required": "This field is required.",
       "alert_save_failed": "Failed to save alert configuration. Check logs and try again.",
       "room_unknown": "Selected room is not in configured telemetry.",
       "room_missing_humidity": "Selected room has no humidity telemetry for room-scoped humidity danger.",
       "room_missing_temp_humidity": "Selected room needs both humidity and temperature telemetry for this room-scoped trigger."
+    },
+    "abort": {
+      "user_cancelled": "Options closed without saving."
     }
   },
   "issues": {


### PR DESCRIPTION
## Summary

Fixes v2.0.6-beta setup/options flow UX issues around telemetry sensor add/edit navigation and Zone 2 trigger ownership. Adds explicit Save/Cancel actions to telemetry add/edit pages, adds close-without-saving confirmation for HI-controlled Cancel actions, defaults Zone 2 to Level 2, and labels zone trigger options with both zone and level context.

## Scope

Scoped to config-flow/options-flow UX and zone trigger label/default correctness.

This PR does not change runtime lane ordering, automation engine behavior, services, sensors, entity semantics, AQ behavior, or generated dashboard runtime behavior.

## Reason

v2.0.6-beta setup users could get stuck on add-sensor pages without a safe in-flow cancel path. Zone 2 trigger labels/defaults could also appear as Level 1 ownership unless manually corrected, creating UI truth risk during setup and post-configuration editing.

## Files affected

- `config_flow.py`
- `strings.json`
- `translations/en.json`
- `CHANGELOG.md`
- `tests 2/test_config_flow_sanity.py`

## Runtime impact

Config/options-flow UX and saved zone defaults only.

No change to:
- deterministic lane ordering
- entity semantics
- services
- outputs
- diagnostics runtime behavior
- sensors
- automation engine
- AQ runtime behavior
- generated dashboard runtime behavior

Zone 2 default ownership is corrected to Level 2 unless the user explicitly selects another level.

## UI impact

Home Assistant setup/options pages now expose explicit Save/Cancel actions for telemetry add/edit flows. Zone trigger labels now include zone plus level context, for example Zone 1 / Level 1 and Zone 2 / Level 2.

Generated dashboards, gallery examples, frontend dependency assumptions, and AQ chip/card behavior are unchanged.

Home Assistant’s native top-left close button cannot be intercepted directly by the integration; the closest supported behavior is implemented through HI-controlled Cancel actions with explicit close-without-saving confirmation.

## Migration impact

None.

Existing users do not need migration steps. A Home Assistant restart or custom integration reload is required to pick up Python/string changes.

## Rollback safety

Safe to revert as a config/options-flow UX patch. Reverting restores the previous telemetry add/edit flow behavior and previous Zone 2 default/trigger-label behavior, without touching runtime entities, services, lane ordering, or generated dashboard files.

## Validation performed

- `python3 'tests 2/test_config_flow_sanity.py'`
- `python3 'tests 2/test_diagnostics.py'`
- `python3 'tests 2/test_slope_sanity.py'`
- `python3 -m py_compile config_flow.py 'tests 2/test_config_flow_sanity.py'`
- `python3 -m compileall -q config_flow.py helpers/zone_validation.py`
- `python3 -m json.tool strings.json`
- `python3 -m json.tool translations/en.json`
- `python3 scripts/check_version_governance.py`
- `git diff --check`

Full direct `test_runtime_card_sanity.py` is blocked in this release checkout by an unrelated README badge assertion.

## Type

- [x] Fix
- [ ] Feature
- [ ] Documentation
- [ ] UI Gallery
- [ ] Maintenance

## Checks

- [ x] PR targets `senyo888-patch-1`.  
  Target is intentionally `senyo888-patch-1` for the v2.0.6-beta branch flow.
- [x] Tested in Home Assistant, or testing notes explain why not.
- [x] Restart/config flow checked where relevant.
- [ ] Ran `humidity_intelligence.refresh_ui` or refreshed dashboards where UI output changed.  
  Not applicable; generated UI output did not change.
- [x] Docs/changelog updated where needed.
- [ ] Support docs, diagnostics guidance, and issue templates updated where support flow changed.  
  Not applicable.
- [x] No private entity IDs, secrets, addresses, or personal data included.
- [x] HACS/custom integration metadata still looks correct.
- [x] Deterministic lane ordering is preserved, or the PR explicitly explains an approved semantic change.
- [x] UI truth consistency is preserved; generated UI does not invent backend state.
- [x] Migration impact is documented, including "none" when no migration is required.
- [x] Release/readiness impact is stated, including whether Bella/Aetherwing/AetherCore review is needed.

## UI Gallery submissions

- [ ] Uses `/ui-gallery/<card-id>/`.
- [ ] Includes `README.md`, `preview.png`, and `card.yaml` or `dashboard.yaml`.
- [ ] Top-level `ui-gallery/README.md` is updated.
- [ ] Example follows `ui-gallery/reference.txt` format.
- [ ] Required custom cards are documented.
- [ ] Preserves canonical Humidity Intelligence backend entities/helpers.
- [ ] Screenshots and YAML contain no private entity IDs, secrets, addresses, device IDs, tokens, internal URLs, or personal data.

Not applicable; this PR does not add or modify UI Gallery submissions.