### PR TITLE
docs: add GitHub Sponsors support links

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: senyo888

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 [![HACS](https://img.shields.io/badge/HACS-Custom%20Integration-orange)](https://hacs.xyz)
 [![Manifest Version](https://img.shields.io/badge/dynamic/json?label=Manifest%20Version&query=%24.version&url=https%3A%2F%2Fraw.githubusercontent.com%2Fsenyo888%2FHumidity-Intelligence%2Fsenyo888-patch-1%2Fmanifest.json&color=blue)](manifest.json)
 [![License](https://img.shields.io/github/license/senyo888/Humidity-Intelligence)](LICENSE)
+[![Sponsor](https://img.shields.io/badge/Sponsor-GitHub%20Sponsors-ea4aaa?logo=githubsponsors&logoColor=white)](https://github.com/sponsors/senyo888)
 
 ## Contents
 
@@ -131,13 +132,20 @@ Additional image files:
 
 ## Support Humidity Intelligence
 
-### ⭐ Enjoying Humidity Intelligence?
+### Enjoying Humidity Intelligence?
 
 If you're finding Humidity Intelligence useful, insightful, or just interesting to explore, consider giving the repository a star.
 
 It helps others discover the project, supports ongoing development, and shows that this kind of deterministic, explainable approach to Home Assistant has community value.
 
 [Star Humidity Intelligence on GitHub](https://github.com/senyo888/Humidity-Intelligence)
+
+Optional sponsorship is also available through GitHub Sponsors:
+
+[Support the project on GitHub Sponsors](https://github.com/sponsors/senyo888)
+
+Sponsorship is optional. It does not create a support SLA, private support obligation, feature guarantee, release commitment, or change to Home Assistant / HACS behaviour.
+
 ---
 
 ## Why Environmental Stability Matters


### PR DESCRIPTION
## Summary

Adds GitHub Sponsors visibility for Humidity Intelligence without changing integration behavior.

## Scope

Documentation/repository-support visibility only:
- README sponsor badge and support wording
- GitHub-native sponsor button configuration via `FUNDING.yml`

## Reason

GitHub Sponsors is now live for `senyo888`, so the repository can expose optional sponsorship support clearly and truthfully.

## Files affected

- `README.md`
- `.github/FUNDING.yml`

## Runtime impact

None. No lane ordering, entity semantics, services, outputs, diagnostics, migrations, or Home Assistant runtime behavior changed.

## UI impact

None. No generated dashboards, Lovelace cards, gallery examples, frontend dependencies, or UI truth surfaces changed.

## Migration impact

None.

## Rollback safety

Safe to revert as a docs-only repository-support change. Reverting removes the README sponsor badge/wording and GitHub Sponsor button configuration only.

## Validation performed

- `git fetch origin develop senyo888-patch-1`
- `git log --oneline origin/develop..senyo888-patch-1`
- `git diff --stat origin/develop...senyo888-patch-1`
- `git diff --name-status origin/develop...senyo888-patch-1`
- `git diff --check origin/develop...senyo888-patch-1`
- Verified sponsor URL: `https://github.com/sponsors/senyo888 200`
- Verified sponsor badge URL returns `HTTP/2 200`
- Home Assistant runtime testing not run because this PR is docs/repository metadata only.

## Type

- [ ] Fix
- [ ] Feature
- [x] Documentation
- [ ] UI Gallery
- [x] Maintenance

## Checks

- [x] PR targets `develop`.
- [x] Tested in Home Assistant, or testing notes explain why not.
- [x] Restart/config flow checked where relevant.
- [x] Ran `humidity_intelligence.refresh_ui` or refreshed dashboards where UI output changed.
- [x] Docs/changelog updated where needed.
- [x] Support docs, diagnostics guidance, and issue templates updated where support flow changed.
- [x] No private entity IDs, secrets, addresses, or personal data included.
- [x] HACS/custom integration metadata still looks correct.
- [x] Deterministic lane ordering is preserved, or the PR explicitly explains an approved semantic change.
- [x] UI truth consistency is preserved; generated UI does not invent backend state.
- [x] Migration impact is documented, including "none" when no migration is required.
- [x] Release/readiness impact is stated, including whether Bella/Aetherwing/AetherCore review is needed.

Release/readiness note: no release claim or release-state change. Bella/Aetherwing sponsor-surface review was completed before implementation; no AetherCore runtime review needed for this docs-only patch.

## UI Gallery submissions

N/A - this PR does not add or modify UI Gallery submissions.

- [x] Uses `/ui-gallery/<card-id>/`.
- [x] Includes `README.md`, `preview.png`, and `card.yaml` or `dashboard.yaml`.
- [x] Top-level `ui-gallery/README.md` is updated.
- [x] Example follows `ui-gallery/reference.txt` format.
- [x] Required custom cards are documented.
- [x] Preserves canonical Humidity Intelligence backend entities/helpers.
- [x] Screenshots and YAML contain no private entity IDs, secrets, addresses, device IDs, tokens, internal URLs, or personal data.
