### PR TITLE
Develop

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: senyo888

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 [![HACS](https://img.shields.io/badge/HACS-Custom%20Integration-orange)](https://hacs.xyz)
 [![Manifest Version](https://img.shields.io/badge/dynamic/json?label=Manifest%20Version&query=%24.version&url=https%3A%2F%2Fraw.githubusercontent.com%2Fsenyo888%2FHumidity-Intelligence%2Fsenyo888-patch-1%2Fmanifest.json&color=blue)](manifest.json)
 [![License](https://img.shields.io/github/license/senyo888/Humidity-Intelligence)](LICENSE)
+[![Sponsor](https://img.shields.io/badge/Sponsor-GitHub%20Sponsors-ea4aaa?logo=githubsponsors&logoColor=white)](https://github.com/sponsors/senyo888)
 
 ## Contents
 
@@ -131,13 +132,20 @@ Additional image files:
 
 ## Support Humidity Intelligence
 
-### ⭐ Enjoying Humidity Intelligence?
+### Enjoying Humidity Intelligence?
 
 If you're finding Humidity Intelligence useful, insightful, or just interesting to explore, consider giving the repository a star.
 
 It helps others discover the project, supports ongoing development, and shows that this kind of deterministic, explainable approach to Home Assistant has community value.
 
 [Star Humidity Intelligence on GitHub](https://github.com/senyo888/Humidity-Intelligence)
+
+Optional sponsorship is also available through GitHub Sponsors:
+
+[Support the project on GitHub Sponsors](https://github.com/sponsors/senyo888)
+
+Sponsorship is optional. It does not create a support SLA, private support obligation, feature guarantee, release commitment, or change to Home Assistant / HACS behaviour.
+
 ---
 
 ## Why Environmental Stability Matters


### PR DESCRIPTION
## Summary

Promotes the GitHub Sponsors support visibility change from `develop` to `main`.

## Scope

Repository-support visibility only:
- README sponsor badge and support wording
- GitHub-native Sponsor button configuration

## Reason

GitHub Sponsors is now live for `senyo888`, and the support surfaces have already landed on `develop`.

## Files affected

- `README.md`
- `.github/FUNDING.yml`

## Runtime impact

None. No lane ordering, entity semantics, services, outputs, diagnostics, migrations, or Home Assistant runtime behavior changed.

## UI impact

None. No generated dashboards, cards, gallery examples, frontend dependency assumptions, or UI truth surfaces changed.

## Migration impact

None.

## Rollback safety

Safe to revert as a docs/repository-metadata change. Reverting removes the README sponsor badge/wording and native GitHub Sponsor button configuration only.

## Validation performed

- `git fetch origin main develop`
- `git log --oneline origin/main..origin/develop`
- `git diff --stat origin/main...origin/develop`
- `git diff --name-status origin/main...origin/develop`
- `git diff --check origin/main...origin/develop`
- Verified sponsor URL: `https://github.com/sponsors/senyo888 200`
- Verified sponsor badge URL returns `HTTP/2 200`
- Home Assistant runtime testing not run because this PR is docs/repository metadata only.

## Type

- [ ] Fix
- [ ] Feature
- [x] Documentation
- [ ] UI Gallery
- [x] Maintenance

## Checks

- [x] PR targets `main`.
- [x] Tested in Home Assistant, or testing notes explain why not.
- [x] Restart/config flow checked where relevant.
- [x] Ran `humidity_intelligence.refresh_ui` or refreshed dashboards where UI output changed.
- [x] Docs/changelog updated where needed.
- [x] Support docs, diagnostics guidance, and issue templates updated where support flow changed.
- [x] No private entity IDs, secrets, addresses, or personal data included.
- [x] HACS/custom integration metadata still looks correct.
- [x] Deterministic lane ordering is preserved, or the PR explicitly explains an approved semantic change.
- [x] UI truth consistency is preserved; generated UI does not invent backend state.
- [x] Migration impact is documented, including "none" when no migration is required.
- [x] Release/readiness impact is stated, including whether Bella/Aetherwing/AetherCore review is needed.

Release/readiness note: this promotes a docs-only Sponsors visibility change to `main`. It does not create a version bump, tag, GitHub release, or runtime release claim. Bella/Aetherwing sponsor-surface review was completed before implementation; no AetherCore runtime review is needed for this docs-only diff.

## UI Gallery submissions

N/A - this PR does not add or modify UI Gallery submissions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added sponsorship information and GitHub Sponsors badge to the documentation.
  * Clarified that sponsorship is optional and does not impact support or behavior.

* **Chores**
  * Added GitHub Sponsors funding configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->