### PR TITLE
Fix first-interaction v3 workflow inputs

### DIFF
--- a/.github/workflows/first-interaction.yml
+++ b/.github/workflows/first-interaction.yml
@@ -21,8 +21,8 @@ jobs:
       - name: Post first interaction welcome
         uses: actions/first-interaction@v3
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          issue-message: |
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          issue_message: |
             ![Humidity Intelligence](https://raw.githubusercontent.com/senyo888/humidity-intelligence/main/assets/header.png)
 
             Thanks for opening your first Humidity Intelligence issue. It is good to have you here.
@@ -39,7 +39,7 @@ jobs:
             If this is an enhancement idea, community discussion and the proposal process are the right place to shape it. Clear problems, real examples, and constructive tradeoffs help maintainers assess the idea, but discussion does not mean every idea will be accepted for implementation.
 
             Thanks for helping make Humidity Intelligence easier to support, explain, and improve.
-          pr-message: |
+          pr_message: |
             ![Humidity Intelligence](https://raw.githubusercontent.com/senyo888/humidity-intelligence/main/assets/header.png)
 
             Thanks for opening your first Humidity Intelligence pull request. Contributions help improve the project, and your time here is appreciated.

--- a/tests 2/test_workflows.py
+++ b/tests 2/test_workflows.py
@@ -1,0 +1,30 @@
+"""Regression checks for GitHub workflow configuration."""
+
+from __future__ import annotations
+
+import pathlib
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+
+class WorkflowConfigurationTests(unittest.TestCase):
+    def test_first_interaction_v3_uses_supported_input_names(self) -> None:
+        workflow = (ROOT / ".github" / "workflows" / "first-interaction.yml").read_text(
+            encoding="utf-8"
+        )
+
+        if "actions/first-interaction@v3" not in workflow:
+            self.skipTest("first-interaction workflow is not using v3")
+
+        self.assertIn("repo_token:", workflow)
+        self.assertIn("issue_message:", workflow)
+        self.assertIn("pr_message:", workflow)
+        self.assertNotIn("repo-token:", workflow)
+        self.assertNotIn("issue-message:", workflow)
+        self.assertNotIn("pr-message:", workflow)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fix the `actions/first-interaction@v3` workflow configuration on `main`.

The Dependabot bump from `v1` to `v3` changed the action input names from hyphenated keys to underscore keys. The workflow was still using the old `repo-token`, `issue-message`, and `pr-message` inputs, so GitHub Actions ignored them and failed with:

`Input required and not supplied: issue_message`

This PR updates the inputs to the v3 names and adds a regression test.

## Scope

GitHub Actions workflow maintenance only.

No Humidity Intelligence runtime, Home Assistant integration logic, generated UI, HACS metadata, release metadata, or documentation behavior changed.

## Reason

The current `main` workflow fails when `actions/first-interaction@v3` runs. This needs to be fixed before using `main` as the clean source for downstream branch syncs into `develop`.

## Files affected

- `.github/workflows/first-interaction.yml`
- `tests 2/test_workflows.py`

## Runtime impact

None. Lane ordering, entity semantics, services, outputs, diagnostics, and migrations are unchanged.

## UI impact

None. Generated dashboards, cards, gallery examples, and frontend dependency assumptions are unchanged.

## Migration impact

None.

## Rollback safety

Safe to revert as workflow-only maintenance. If this regresses, revert this PR and either restore the previous known-good `actions/first-interaction@v1`/pinned-v1 configuration or rework the v3 configuration separately.

No Home Assistant rollback, restart, reload, migration, or dashboard refresh is required.

## Validation performed

- Reproduced the failure condition with a new regression test:
  - `python3 -m unittest "tests 2/test_workflows.py"` failed before the workflow fix.
- Verified the fix:
  - `python3 -m unittest "tests 2/test_workflows.py"` passed.
  - `python3 -m unittest discover -s "tests 2" -p "test_*.py"` passed, 27 tests.
  - `git diff --check` passed.

Home Assistant runtime testing was not run because this PR only changes a GitHub Actions workflow and a workflow regression test.

## Type

- [x] Fix
- [ ] Feature
- [ ] Documentation
- [ ] UI Gallery
- [x] Maintenance

## Checks

- [x] PR targets `main`.
- [x] Tested in Home Assistant, or testing notes explain why not.
- [x] Restart/config flow checked where relevant.
- [x] Ran `humidity_intelligence.refresh_ui` or refreshed dashboards where UI output changed.
- [x] Docs/changelog updated where needed.
- [x] Support docs, diagnostics guidance, and issue templates updated where support flow changed.
- [x] No private entity IDs, secrets, addresses, or personal data included.
- [x] HACS/custom integration metadata still looks correct.
- [x] Deterministic lane ordering is preserved, or the PR explicitly explains an approved semantic change.
- [x] UI truth consistency is preserved; generated UI does not invent backend state.
- [x] Migration impact is documented, including "none" when no migration is required.
- [x] Release/readiness impact is stated, including whether Bella/Aetherwing/AetherCore review is needed.

Release/readiness impact: workflow maintenance only. Bella/Aetherwing/AetherCore review is not required for runtime safety because no runtime, UI, entity, service, diagnostics, HACS, or migration behavior changed.

## UI Gallery submissions

Not applicable. This PR does not add or modify UI Gallery content.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions first-interaction workflow configuration for compatibility.

* **Tests**
  * Added regression test for first-interaction workflow to ensure continued proper functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->