### PR TITLE
Bella/fix first interaction v3 inputs

### DIFF
--- a/.github/workflows/first-interaction.yml
+++ b/.github/workflows/first-interaction.yml
@@ -19,7 +19,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Post first interaction welcome
-        uses: actions/first-interaction@v3
+        uses: actions/first-interaction@1c4688942c71f71d4f5502a26ea67c331730fa4d # v3
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           issue_message: |

--- a/.github/workflows/hacs.yml
+++ b/.github/workflows/hacs.yml
@@ -20,9 +20,9 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: HACS Action
-        uses: hacs/action@main
+        uses: hacs/action@1ebf01c408f29afcb6406bd431bc98fd8cbb15aa # main
         with:
           category: integration

--- a/tests 2/test_workflows.py
+++ b/tests 2/test_workflows.py
@@ -3,11 +3,18 @@
 from __future__ import annotations
 
 import pathlib
+import re
 import unittest
 
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]
 FIRST_INTERACTION_V3_SHA = "1c4688942c71f71d4f5502a26ea67c331730fa4d"
+ACTIONS_CHECKOUT_V6_SHA = "df4cb1c069e1874edd31b4311f1884172cec0e10"
+HACS_ACTION_MAIN_SHA = "1ebf01c408f29afcb6406bd431bc98fd8cbb15aa"
+MUTABLE_ACTION_REF_RE = re.compile(
+    r"^\s*uses:\s*[^@\s]+@(main|master|v?\d+(?:\.\d+){0,2})\s*(?:#.*)?$",
+    re.MULTILINE,
+)
 
 
 class WorkflowConfigurationTests(unittest.TestCase):
@@ -24,6 +31,29 @@ class WorkflowConfigurationTests(unittest.TestCase):
         self.assertNotIn("repo-token:", workflow)
         self.assertNotIn("issue-message:", workflow)
         self.assertNotIn("pr-message:", workflow)
+
+    def test_hacs_validation_actions_are_pinned_to_reviewed_commits(self) -> None:
+        workflow = (ROOT / ".github" / "workflows" / "hacs.yml").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn(f"actions/checkout@{ACTIONS_CHECKOUT_V6_SHA} # v6", workflow)
+        self.assertIn(f"hacs/action@{HACS_ACTION_MAIN_SHA} # main", workflow)
+        self.assertNotIn("actions/checkout@v6", workflow)
+        self.assertNotIn("hacs/action@main", workflow)
+
+    def test_workflow_actions_do_not_use_mutable_refs(self) -> None:
+        mutable_refs = []
+        for workflow_path in sorted((ROOT / ".github" / "workflows").glob("*.y*ml")):
+            workflow = workflow_path.read_text(encoding="utf-8")
+            for match in MUTABLE_ACTION_REF_RE.finditer(workflow):
+                line_number = workflow[: match.start()].count("\n") + 1
+                relative_path = workflow_path.relative_to(ROOT)
+                mutable_refs.append(
+                    f"{relative_path}:{line_number}: {match.group(0).strip()}"
+                )
+
+        self.assertEqual([], mutable_refs)
 
 
 if __name__ == "__main__":

--- a/tests 2/test_workflows.py
+++ b/tests 2/test_workflows.py
@@ -7,17 +7,17 @@ import unittest
 
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]
+FIRST_INTERACTION_V3_SHA = "1c4688942c71f71d4f5502a26ea67c331730fa4d"
 
 
 class WorkflowConfigurationTests(unittest.TestCase):
-    def test_first_interaction_v3_uses_supported_input_names(self) -> None:
+    def test_first_interaction_v3_is_pinned_and_uses_supported_input_names(self) -> None:
         workflow = (ROOT / ".github" / "workflows" / "first-interaction.yml").read_text(
             encoding="utf-8"
         )
 
-        if "actions/first-interaction@v3" not in workflow:
-            self.skipTest("first-interaction workflow is not using v3")
-
+        self.assertIn(f"actions/first-interaction@{FIRST_INTERACTION_V3_SHA} # v3", workflow)
+        self.assertNotIn("actions/first-interaction@v3", workflow)
         self.assertIn("repo_token:", workflow)
         self.assertIn("issue_message:", workflow)
         self.assertIn("pr_message:", workflow)


### PR DESCRIPTION
## Summary

Fixes the GitHub Actions first-interaction workflow for `actions/first-interaction@v3` by using the supported snake_case input names. Also pins workflow actions to immutable commit SHAs for the first-interaction and HACS validation workflows, with regression tests to prevent mutable refs from returning.

## Scope

Small GitHub Actions maintenance/fix PR from `bella/fix-first-interaction-v3-inputs` to `main`.

## Reason

The first-interaction workflow failed because v3 expects `repo_token`, `issue_message`, and `pr_message`, not hyphenated input names. Code review also flagged mutable workflow action refs, so this hardens the workflow supply-chain surface before release branch work continues.

## Files affected

- `.github/workflows/first-interaction.yml`
- `.github/workflows/hacs.yml`
- `tests 2/test_workflows.py`

## Runtime impact

None. No lane ordering, entity semantics, services, outputs, diagnostics, Home Assistant runtime behavior, or migrations changed.

## UI impact

None. No generated dashboards, cards, UI gallery examples, or frontend dependency assumptions changed.

## Migration impact

None. Users do not need to take action.

## Rollback safety

Safe to revert as a normal workflow-only PR if it regresses. Reverting would restore the previous workflow configuration, but would also bring back the first-interaction v3 input failure and mutable action refs.

## Validation performed

- `python3 -m unittest 'tests 2/test_workflows.py'`
- `python3 -m unittest discover -s 'tests 2' -p 'test_*.py'` — 29 tests passed
- `actionlint .github/workflows/hacs.yml`
- `git diff --check`
- Mutable workflow action ref scan returned no matches

Home Assistant runtime testing was not performed because this PR only changes GitHub workflow configuration and workflow regression tests.

## Type

- [x] Fix
- [ ] Feature
- [ ] Documentation
- [ ] UI Gallery
- [x] Maintenance

## Checks

- [x] PR targets `main`.
- [x] Tested in Home Assistant, or testing notes explain why not.
- [x] Restart/config flow checked where relevant.
- [x] Ran `humidity_intelligence.refresh_ui` or refreshed dashboards where UI output changed.
- [x] Docs/changelog updated where needed.
- [x] Support docs, diagnostics guidance, and issue templates updated where support flow changed.
- [x] No private entity IDs, secrets, addresses, or personal data included.
- [x] HACS/custom integration metadata still looks correct.
- [x] Deterministic lane ordering is preserved, or the PR explicitly explains an approved semantic change.
- [x] UI truth consistency is preserved; generated UI does not invent backend state.
- [x] Migration impact is documented, including "none" when no migration is required.
- [x] Release/readiness impact is stated, including whether Bella/Aetherwing/AetherCore review is needed.

Release/readiness impact: Bella review is appropriate for the workflow fix. Aetherwing/AetherCore runtime review is not required because no runtime, entity, service, migration, or generated UI behavior changed.

## UI Gallery submissions

- [ ] Uses `/ui-gallery/<card-id>/`.
- [ ] Includes `README.md`, `preview.png`, and `card.yaml` or `dashboard.yaml`.
- [ ] Top-level `ui-gallery/README.md` is updated.
- [ ] Example follows `ui-gallery/reference.txt` format.
- [ ] Required custom cards are documented.
- [ ] Preserves canonical Humidity Intelligence backend entities/helpers.
- [ ] Screenshots and YAML contain no private entity IDs, secrets, addresses, device IDs, tokens, internal URLs, or personal data.

Not applicable. This PR does not include UI Gallery submissions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * GitHub Actions workflows updated to use pinned commit references instead of flexible version tags.
  * Added automated validation tests to ensure workflow action references remain properly pinned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->