### PR TITLE
Adopt reviewed HI Support Bundle Inspector on newest patch branch

### DIFF
--- a/scripts/generate_hi_inspector_fixtures.py
+++ b/scripts/generate_hi_inspector_fixtures.py
@@ -309,7 +309,7 @@ def _check(
     fixture_root = fixture_root or FIXTURE_ROOT
     failures: list[str] = []
     tracked: dict[str, dict[str, Any]] = {}
-    for filename, payload in fixtures.items():
+    for filename in fixtures:
         path = fixture_root / filename
         if not path.is_file():
             failures.append(f"missing fixture {filename}")

--- a/scripts/issue_triage.py
+++ b/scripts/issue_triage.py
@@ -371,6 +371,11 @@ _ENTITY_ID_RE = re.compile(
     re.I,
 )
 _SHARED_IPV4_NETWORK = ipaddress.ip_network("100.64.0.0/10")
+_SUMMARY_REDACTION_INPUT_FACTOR = 8
+_OVERSIZE_SUMMARY_MESSAGE = (
+    "Issue body summary omitted because selected content exceeds the safe "
+    "processing limit."
+)
 
 
 def _is_private_address(address: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
@@ -474,6 +479,8 @@ def _body_summary(body: Any, *, max_chars: int = 320) -> str:
 
     summary = " ".join(lines) if lines else body.strip()
     summary = re.sub(r"\s+", " ", summary)
+    if len(summary) > max_chars * _SUMMARY_REDACTION_INPUT_FACTOR:
+        summary = _OVERSIZE_SUMMARY_MESSAGE
     summary = _redact_issue_summary_privacy(summary)
     if len(summary) > max_chars:
         return summary[: max_chars - 1].rstrip() + "..."
@@ -1105,10 +1112,8 @@ def _detect_inspector_handoff(body: Any) -> str:
         return "invalid"
     schema = block[4].removeprefix("Backend diagnostics schema: ")
     if (
-        source_status == "native-summary"
-        and schema != "1"
-        or source_status == "dump-summary"
-        and schema != "not-reported"
+        (source_status == "native-summary" and schema != "1")
+        or (source_status == "dump-summary" and schema != "not-reported")
     ):
         return "invalid"
 

--- a/site/inspector/handoff.mjs
+++ b/site/inspector/handoff.mjs
@@ -2,6 +2,7 @@ export const HANDOFF_CONTRACT = "HI-SUPPORT-HANDOFF/1";
 export const HANDOFF_END = "HI-SUPPORT-HANDOFF-END/1";
 export const INSPECTOR_VERSION = "0.3.0-beta.1";
 export const MAX_HANDOFF_LENGTH = 4096;
+export const MAX_HANDOFF_LINE_LENGTH = 240;
 
 const MAX_COUNT = 1_000_000;
 const SOURCE_FORMATS = new Set([
@@ -99,7 +100,7 @@ export function createSupportHandoff(report) {
   const text = lines.join("\n");
   if (
     text.length > MAX_HANDOFF_LENGTH ||
-    lines.some((line) => line.length > 240)
+    lines.some((line) => line.length > MAX_HANDOFF_LINE_LENGTH)
   ) {
     return unavailable();
   }

--- a/site/inspector/styles.css
+++ b/site/inspector/styles.css
@@ -234,7 +234,6 @@ h3 {
   width: 1px;
   height: 1px;
   overflow: hidden;
-  clip: rect(0 0 0 0);
   white-space: nowrap;
   clip-path: inset(50%);
 }

--- a/tests 2/test_hi_inspector.mjs
+++ b/tests 2/test_hi_inspector.mjs
@@ -19,6 +19,7 @@ import {
   HANDOFF_END,
   INSPECTOR_VERSION,
   MAX_HANDOFF_LENGTH,
+  MAX_HANDOFF_LINE_LENGTH,
   PRIVACY_CATEGORIES,
   PRIVACY_CATEGORY_CODES,
   WARNING_CATEGORIES,
@@ -155,7 +156,7 @@ test("native report produces the exact bounded handoff contract", () => {
     "Configuration counts: zones=1; aq-lanes=0; humidifier-lanes=0; alert-rules=1",
   );
   assert.ok(handoff.text.length <= MAX_HANDOFF_LENGTH);
-  assert.ok(lines.every((line) => line.length <= 240));
+  assert.ok(lines.every((line) => line.length <= MAX_HANDOFF_LINE_LENGTH));
   assert.doesNotMatch(handoff.text, /telemetry/i);
   assert.doesNotMatch(handoff.text, /active lane|reason available/i);
 });
@@ -197,7 +198,7 @@ test("every allowlisted category fits the handoff line and block bounds", () => 
   assert.equal(handoff.ok, true);
   const lines = handoff.text.split("\n");
   assert.ok(handoff.text.length <= MAX_HANDOFF_LENGTH);
-  assert.ok(lines.every((line) => line.length <= 240));
+  assert.ok(lines.every((line) => line.length <= MAX_HANDOFF_LINE_LENGTH));
   for (const [, code] of [
     ...WARNING_CATEGORY_CODES,
     ...PRIVACY_CATEGORY_CODES,
@@ -325,9 +326,9 @@ test("dump summary cannot invent runtime or version truth", () => {
 
 test("privacy review reports categories without retaining matched values", () => {
   const payload = fixture("native_schema1.json");
-  const privateUrl =
-    "https://private.example.invalid/path?token=VeryPrivateToken_123456";
-  payload.privacy["secret"] = "VeryPrivateToken_123456";
+  const secretSentinel = "FIXTURE_PLACEHOLDER_VALUE_1";
+  const privateUrl = `https://private.example.invalid/path?token=${secretSentinel}`;
+  payload.privacy.secret_like_field = secretSentinel;
   payload.privacy.support_url = privateUrl;
   payload.privacy.owner_email = "fixture-owner@example.invalid";
 
@@ -342,7 +343,7 @@ test("privacy review reports categories without retaining matched values", () =>
   assert.ok(categories.includes("Email address"));
 
   const rendered = JSON.stringify(result.report);
-  assert.doesNotMatch(rendered, /VeryPrivateToken_123456/);
+  assert.doesNotMatch(rendered, /FIXTURE_PLACEHOLDER_VALUE_1/);
   assert.doesNotMatch(rendered, /private\.example\.invalid/);
   assert.doesNotMatch(rendered, /fixture-owner@example\.invalid/);
 });

--- a/tests 2/test_issue_triage.py
+++ b/tests 2/test_issue_triage.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import importlib.util
 import pathlib
+import shutil
 import stat
 import subprocess
 import sys
@@ -67,6 +68,8 @@ const handoff = createSupportHandoff(parsed.report);
 if (!handoff.ok) process.exit(3);
 process.stdout.write(handoff.text);
 """
+        if shutil.which("node") is None:
+            self.skipTest("node is required for cross-language handoff tests")
         completed = subprocess.run(
             ["node", "--input-type=module", "--eval", script],
             cwd=ROOT,
@@ -923,11 +926,6 @@ forbidden_actions:
                 self.assertEqual(analyzed.priority, "P0")
                 self.assertEqual(analyzed.confidence, "high")
                 self.assertEqual(analyzed.release_blocker, "yes")
-                if len(safety_line) > self.triage.HANDOFF_MAX_LINE_CHARS:
-                    self.assertGreater(
-                        len(safety_line),
-                        self.triage.HANDOFF_MAX_LINE_CHARS,
-                    )
 
     def test_inspector_handoff_status_is_escaped_and_raw_block_is_not_rendered(self) -> None:
         handoff = self._generated_handoff("native_schema1.json")
@@ -1126,6 +1124,35 @@ forbidden_actions:
             truncated,
             expected_source[:39].rstrip() + "...",
         )
+
+    def test_issue_summary_bounds_privacy_filter_input(self) -> None:
+        max_chars = 320
+        input_limit = max_chars * self.triage._SUMMARY_REDACTION_INPUT_FACTOR
+        path_prefix = "/Users/example/HI Work folder/"
+        long_path = (
+            path_prefix
+            + ("a" * (input_limit - len(path_prefix) - 1))
+            + "/private-end, ordinary prose"
+        )
+        self.assertEqual(
+            self.triage._redact_issue_summary_privacy(long_path),
+            "[redacted local path], ordinary prose",
+        )
+
+        with mock.patch.object(
+            self.triage,
+            "_redact_issue_summary_privacy",
+            side_effect=lambda value: value,
+        ) as redact:
+            summary = self.triage._body_summary(long_path, max_chars=max_chars)
+
+        self.assertLessEqual(
+            len(redact.call_args.args[0]),
+            input_limit,
+        )
+        self.assertEqual(summary, self.triage._OVERSIZE_SUMMARY_MESSAGE)
+        self.assertNotIn("HI Work folder", summary)
+        self.assertNotIn("private-end", summary)
 
     def test_issue_summary_privacy_redacts_decorated_secrets_mapped_ipv6_and_paths(
         self,

--- a/tests 2/test_pages_site.py
+++ b/tests 2/test_pages_site.py
@@ -137,8 +137,9 @@ class PagesSiteTests(unittest.TestCase):
         self.assertIn('id="support"', html)
         self.assertIn("Support Humidity Intelligence", html)
         self.assertTrue(required_targets.issubset(set(parser.links)))
-        self.assertEqual(parser.links.count("inspector/"), 1)
-        self.assertEqual(urljoin(PAGES_URL, "inspector/"), INSPECTOR_URL)
+        inspector_links = [link for link in parser.links if link == "inspector/"]
+        self.assertEqual(len(inspector_links), 1)
+        self.assertEqual(urljoin(PAGES_URL, inspector_links[0]), INSPECTOR_URL)
 
     def test_referenced_site_assets_are_public_and_copied_by_workflow(self) -> None:
         _html, parser = parse_index()


### PR DESCRIPTION
## Scope

- Adds the same-origin `/humidity-intelligence/inspector/` browser-local support utility.
- Implements the versioned manual `HI-SUPPORT-HANDOFF/1` contract and optional issue-form intake.
- Adds report-only triage recognition, privacy-filtered issue summaries, backend-produced compatibility fixtures, and main-ref-only Pages guards.
- Preserves the established GitHub Pages landing page as the primary public gateway, with one subordinate Inspector link.
- Includes the complete post-review hardening delta from stable PR #80.

## Reason

The Inspector turns sanitized HI diagnostics into a readable support report in the browser and creates an explicit manual handoff for issue triage. This provides focused support utility beyond the existing landing and documentation surfaces while keeping runtime and proposal truth with HI, Home Assistant, and the repository.

## Files affected

- `site/inspector/`, landing-page link, and Inspector build/fixture scripts
- support and issue-triage documentation
- optional GitHub issue-form handoff fields
- report-only triage recognition and privacy filtering
- Pages branch guards and bounded Inspector/triage/Pages tests

## Runtime impact

None. Home Assistant and the HI backend remain runtime authority. The Inspector consumes sanitized diagnostics and version-stamped backend fixtures; it contains no parallel decision engine or service/control path.

## Entity semantics

Unchanged. Entity, helper, service, device, registry, and telemetry semantics retain their current contracts.

## UI impact

The existing public landing remains primary and gains one relative Inspector link. The Inspector is responsive, keyboard accessible, touch usable, browser-local, and marked beta. Generated Home Assistant dashboards and reason panels are unchanged.

## Migration impact

None. Current Home Assistant, HACS, configuration, dashboard, and helper state continues without restart, reload, regeneration, or migration steps.

## Privacy and retention

Diagnostic processing is local and in-memory, with zero analytics, persistence, external upload, HA token use, or connector access. Clipboard handoff is explicit. Issue-summary filtering redacts credentials, private/local network details, local paths, device IDs, and entity IDs while preserving useful public evidence. Pathological oversized summary selections become a fixed safe omission message before complex privacy regex processing.

## Validation performed

- Engineering Python matrix: 309/309 passed
- Inspector Node suite: 20/20 passed
- Backend fixture generation/currentness: passed at `2.0.9-beta.1`
- Production static build: six expected files passed
- Desktop/mobile browser QA: valid render, keyboard flow, invalid-input fail-closed behavior, privacy wording, same-origin-only requests, and zero console errors passed
- Version governance, Python compilation, `git diff --check`, and gitleaks: passed
- CodeRabbit’s two actionable threads and seven bounded review points addressed; dedicated re-review clean
- Bella, AetherCore, Aetherwing, and Aetherbite final reviews: clean

## Deterministic lane and UI-truth risk

No lane-ordering change. One deterministic ventilation decision per evaluation cycle remains backend-owned. Inspector output reports existing diagnostics only; unknown, invalid, and unavailable inputs fail closed. Generated UI truth remains backend-aligned.

## Documentation and release impact

README/support/triage guidance is aligned with the bounded beta. Repository files remain support, proposal, and release truth. Wiki update status is a recorded no-op because current repository guidance is sufficient. Manifest, HACS metadata, runtime release version, and release notes remain unchanged.

## Rollback safety

Revert the eight bounded commits or remove the subordinate landing link and Inspector static directory. Runtime and Home Assistant state require no rollback action.