### PR TITLE
Finalize v2.0.9 promotion readiness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This project follows a practical changelog format for Home Assistant and HACS us
 
 ## Unreleased
 
+No unreleased changes.
+
+## 2.0.9 - 2026-07-28
+
 - Added the optional HI Support Bundle Inspector to the Pages artifact as a
   separate, noindex preflight at `/humidity-intelligence/inspector/`. Diagnostic parsing and
   handoff generation remain browser-local with zero automatic or network
@@ -16,11 +20,10 @@ This project follows a practical changelog format for Home Assistant and HACS us
   support attachment and the repository/Wiki remain support truth. Wiki update
   status: `no-op` because existing diagnostics guidance remains authoritative.
   Release-documentation status: `updated` by this entry.
-- Promoted working-branch integration metadata to stable `2.0.9` after local release
-  validation and extended the
-  backward-compatible `v205_release_check` manifest contract through the v2.0.9
-  beta/rc/stable line. Publication remains pending; the latest published stable
-  release remains v2.0.8.
+- Set integration metadata to stable `2.0.9`, aligned the release documentation, and
+  extended the backward-compatible `v205_release_check` manifest contract through
+  the v2.0.9 beta/rc/stable line. GitHub Releases and HACS remain the authoritative
+  publication and installed-package records.
 - Removed the HACS `country` metadata so Humidity Intelligence can be listed
   globally instead of being limited to the GB store scope.
 - Restricted custom filenames for `dump_diagnostics` and `v205_release_check` to

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![Latest Release](https://img.shields.io/github/v/release/senyo888/Humidity-Intelligence?display_name=tag&sort=semver)](https://github.com/senyo888/Humidity-Intelligence/releases)
 [![Project Site](https://img.shields.io/badge/Project%20Site-GitHub%20Pages-5aa8d6)](https://senyo888.github.io/humidity-intelligence/)
 [![HACS](https://img.shields.io/badge/HACS-Custom%20Integration-orange)](https://hacs.xyz)
-[![Manifest Version](https://img.shields.io/badge/dynamic/json?label=Manifest%20Version&query=%24.version&url=https%3A%2F%2Fraw.githubusercontent.com%2Fsenyo888%2FHumidity-Intelligence%2Fsenyo888-patch-1%2Fmanifest.json&color=blue)](manifest.json)
+[![Manifest Version](https://img.shields.io/badge/dynamic/json?label=Manifest%20Version&query=%24.version&url=https%3A%2F%2Fraw.githubusercontent.com%2Fsenyo888%2FHumidity-Intelligence%2Fmain%2Fmanifest.json&color=blue)](https://github.com/senyo888/Humidity-Intelligence/blob/main/manifest.json)
 [![License](https://img.shields.io/github/license/senyo888/Humidity-Intelligence)](LICENSE)
 [![Sponsor](https://img.shields.io/badge/Sponsor-GitHub%20Sponsors-ea4aaa?logo=githubsponsors&logoColor=white)](https://github.com/sponsors/senyo888)
 
@@ -66,9 +66,8 @@ HACS as the user-facing record.
 v2.0.9 completes the HI-owned runtime-artifact namespace: report JSON writes
 under `<config>/humidity_intelligence/exports/`, generated card YAML writes under
 `<config>/humidity_intelligence/ui/`, and external report/card writer services
-require an authenticated admin context. Stable `2.0.9` metadata is staged locally
-after release validation, but it is not yet a published release; the latest
-published stable release remains v2.0.8.
+require an authenticated admin context. GitHub Releases and HACS remain the
+authoritative publication and installed-package records.
 
 The deterministic runtime contract stays intact: one selected control lane per cycle,
 the same public entity meanings, and output writing only through the established
@@ -385,8 +384,9 @@ must be reviewable from tracked repository files.
 
 ## Current Release Highlights
 
-- working-branch integration metadata is stable `2.0.9`; GitHub Releases and HACS
-  remain the user-facing record for the latest published stable release, v2.0.8
+- integration metadata and release documentation identify stable `2.0.9`; GitHub
+  Releases and HACS remain the authoritative publication and installed-package
+  records
 - the browser-local
   [HI Support Bundle Inspector](https://senyo888.github.io/humidity-intelligence/inspector/)
   provides an optional inspect-before-sharing preflight: diagnostics content stays
@@ -1092,11 +1092,9 @@ CO emergency pressure. Details are in
 
 ### v2.0.9
 
-![Humidity Intelligence v2.0.9 release banner](assets/release_banner/v2.0.9_release.png)
-
-- promoted working-branch integration metadata to stable `2.0.9` after local release
-  validation; publication remains pending and v2.0.8 remains the latest published
-  stable release
+- set integration metadata to stable `2.0.9` and aligned the release documentation;
+  GitHub Releases and HACS remain the authoritative publication and installed-package
+  records
 - added the optional browser-local HI Support Bundle Inspector preflight so users
   can inspect supported diagnostics and copy a bounded advisory handoff before
   sharing; diagnostic contents are not uploaded, logged, analyzed remotely, or

--- a/docs/release-governance.md
+++ b/docs/release-governance.md
@@ -15,15 +15,13 @@ testing and validation branches.
 The integration version in `manifest.json` is the release-state source of truth for
 Home Assistant and HACS metadata checks.
 
-v2.0.8 is the latest published stable release line. Tag and GitHub Release `v2.0.8`
-were published from `main` on 2026-07-06.
-
-The working metadata on `senyo888-patch-1` is stable `2.0.9` after local release
-validation. That branch state is not a tag, GitHub Release, HACS publication,
-`develop` promotion, or `main` promotion. Release readiness for this line must still
-be established through public-safe validation summaries, GitHub CI, the required
-review gates, and explicit maintainer approval. Local operational evidence does not
-replace or become part of the tracked public correctness contract.
+The tracked source and release documentation identify stable `2.0.9`. A branch or
+merge containing stable metadata is not by itself a tag, GitHub Release, or HACS
+publication. Public release status comes from GitHub Releases and HACS, while
+release readiness must be established through public-safe validation summaries,
+GitHub CI, the required review gates, and explicit maintainer approval. Local
+operational evidence does not replace or become part of the tracked public
+correctness contract.
 
 The former v2.0.8 candidate moved through `senyo888-patch-1`, `develop`, and `main`
 before publication. Stable metadata on a staging or review branch was not release

--- a/legacy/ui-gallery/house-average-humidity-badge-mobile-ui/house-average-humidity-badge-mobile_dashboard.yaml
+++ b/legacy/ui-gallery/house-average-humidity-badge-mobile-ui/house-average-humidity-badge-mobile_dashboard.yaml
@@ -49,7 +49,7 @@ cards:
       ]]]
     styles:
       grid:
-        - grid-template-areas: ""i s""
+        - grid-template-areas: '"i s"'
         - grid-template-columns: 52px 1fr
         - align-items: center
         - column-gap: 12px

--- a/legacy/ui-gallery/house-average-temperature-badge-mobile-ui/house-average-temperature-badge-mobile_dashboard.yaml
+++ b/legacy/ui-gallery/house-average-temperature-badge-mobile-ui/house-average-temperature-badge-mobile_dashboard.yaml
@@ -66,7 +66,7 @@ cards:
               return '0 0 26px rgba(239,68,68,0.65)';
             ]]]
       grid:
-        - grid-template-areas: ""i s" "i l""
+        - grid-template-areas: '"i s" "i l"'
         - grid-template-columns: 40px 1fr
         - grid-template-rows: 1fr auto
         - align-items: center

--- a/legacy/ui-gallery/humidity-core-tablet-ui/humidity-core-tablet_dashboard.yaml
+++ b/legacy/ui-gallery/humidity-core-tablet-ui/humidity-core-tablet_dashboard.yaml
@@ -280,7 +280,7 @@ cards:
                            '0 0 18px rgba(148,163,184,0.18)';
                   ]]]
             grid:
-              - grid-template-areas: ""i n s" "i l l""
+              - grid-template-areas: '"i n s" "i l l"'
               - grid-template-columns: 60px 1fr auto
               - column-gap: 10px
             name:
@@ -342,7 +342,7 @@ cards:
                            '0 0 18px rgba(148,163,184,0.18)';
                   ]]]
             grid:
-              - grid-template-areas: ""i n s" "i l l""
+              - grid-template-areas: '"i n s" "i l l"'
               - grid-template-columns: 60px 1fr auto
               - column-gap: 10px
             name:

--- a/tests 2/test_doc_banners.py
+++ b/tests 2/test_doc_banners.py
@@ -30,6 +30,13 @@ RELEASE_BANNER_FAMILY = (
 PUBLISHED_V208_BANNER_SHA256 = (
     "9bd301840c764af85d443a22912f73e67b98a181045db8193c052d15fb560b78"
 )
+MAIN_MANIFEST_BADGE_SOURCE = (
+    "raw.githubusercontent.com%2Fsenyo888%2FHumidity-Intelligence%2Fmain"
+    "%2Fmanifest.json"
+)
+MAIN_MANIFEST_LINK = (
+    "https://github.com/senyo888/Humidity-Intelligence/blob/main/manifest.json"
+)
 
 
 def _asset_path(doc_path: pathlib.Path, markdown_line: str) -> pathlib.Path:
@@ -80,6 +87,29 @@ class DocumentationBannerTests(unittest.TestCase):
 
         v209_bytes = (release_banner_dir / "v2.0.9_release.png").read_bytes()
         self.assertEqual(struct.unpack(">II", v209_bytes[16:24]), (1600, 900))
+
+    def test_v209_release_docs_use_main_and_versioned_release_truth(self) -> None:
+        readme = (ROOT / "README.md").read_text(encoding="utf-8")
+        changelog = (ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
+
+        self.assertIn(MAIN_MANIFEST_BADGE_SOURCE, readme)
+        self.assertIn(MAIN_MANIFEST_LINK, readme)
+        self.assertNotIn(
+            "Humidity-Intelligence%2Fsenyo888-patch-1%2Fmanifest.json",
+            readme,
+        )
+        self.assertEqual(
+            readme.count(
+                "![Humidity Intelligence v2.0.9 release banner]"
+                "(assets/release_banner/v2.0.9_release.png)"
+            ),
+            0,
+        )
+        self.assertIn("## 2.0.9 - 2026-07-28", changelog)
+        self.assertLess(
+            changelog.index("## Unreleased"),
+            changelog.index("## 2.0.9 - 2026-07-28"),
+        )
 
 
 if __name__ == "__main__":

--- a/tests 2/test_issue_triage.py
+++ b/tests 2/test_issue_triage.py
@@ -282,8 +282,8 @@ priority: P1
 status: open
 source:
   type: manual
-  ref: "/Users/senyo/private-ha-lab"
-instruction: "Use /Users/senyo/private-ha-lab and then label the GitHub issue."
+  ref: "/Users/example/private-lab"
+instruction: "Use /Users/example/private-lab and then label the GitHub issue."
 completion_criteria:
   - "Unsafe instruction should not be accepted."
 allowed_actions: [report, mutate_github_issue]
@@ -333,8 +333,8 @@ forbidden_actions:
 
     def test_public_safety_rejects_cross_platform_local_paths(self) -> None:
         for local_path in (
-            "/home/runner/work/private-ha-lab",
-            r"C:\Users\Senyo\private-ha-lab",
+            "/home/example/work/private-lab",
+            r"C:\Users\Example\private-lab",
         ):
             with self.subTest(local_path=local_path):
                 issue = self.triage._public_safety_issue({"instruction": local_path})

--- a/tests 2/test_runtime_card_sanity.py
+++ b/tests 2/test_runtime_card_sanity.py
@@ -169,6 +169,9 @@ def _install_homeassistant_stubs(*, include_unit_ratio: bool = True) -> None:
     class Invalid(Exception):
         pass
 
+    ALLOW_EXTRA = object()
+    PREVENT_EXTRA = object()
+
     class _SchemaKey:
         def __init__(self, key, default=None):
             self.key = key
@@ -181,8 +184,9 @@ def _install_homeassistant_stubs(*, include_unit_ratio: bool = True) -> None:
                 return hash((self.key, repr(self.default)))
 
     class Schema:
-        def __init__(self, schema):
+        def __init__(self, schema, extra=PREVENT_EXTRA):
             self.schema = schema
+            self.extra = extra
 
         def __call__(self, value):
             if not isinstance(self.schema, dict):
@@ -190,7 +194,17 @@ def _install_homeassistant_stubs(*, include_unit_ratio: bool = True) -> None:
             if not isinstance(value, dict):
                 raise Invalid("schema value must be a mapping")
 
-            validated = dict(value)
+            declared_keys = {
+                key_spec.key if isinstance(key_spec, _SchemaKey) else key_spec
+                for key_spec in self.schema
+            }
+            unexpected_keys = set(value) - declared_keys
+            if unexpected_keys and self.extra is not ALLOW_EXTRA:
+                raise Invalid(
+                    f"extra keys not allowed: {sorted(unexpected_keys)!r}"
+                )
+
+            validated = dict(value) if self.extra is ALLOW_EXTRA else {}
             for key_spec, validator in self.schema.items():
                 key = key_spec.key if isinstance(key_spec, _SchemaKey) else key_spec
                 if key in value:
@@ -306,6 +320,8 @@ def _install_homeassistant_stubs(*, include_unit_ratio: bool = True) -> None:
     voluptuous.Range = _range
     voluptuous.All = _all
     voluptuous.Any = _any
+    voluptuous.ALLOW_EXTRA = ALLOW_EXTRA
+    voluptuous.PREVENT_EXTRA = PREVENT_EXTRA
 
     sys.modules["homeassistant"] = ha
     sys.modules["homeassistant.core"] = core
@@ -3736,7 +3752,7 @@ def test_readme_only_shows_two_latest_release_notes_before_previous_releases():
     assert "### v2.0.9" in visible_notes
     assert "### v2.0.8" in visible_notes
     assert "### v2.0.7" not in visible_notes
-    assert "assets/release_banner/v2.0.9_release.png" in visible_notes
+    assert "assets/release_banner/v2.0.9_release.png" not in visible_notes
     assert (ROOT / "assets" / "release_banner" / "v2.0.9_release.png").read_bytes()[:8] == (
         b"\x89PNG\r\n\x1a\n"
     )
@@ -3880,6 +3896,28 @@ def test_card_exports_are_entry_qualified_only_for_multi_entry_installations():
             / "ui"
             / boundary_name
         ).is_file()
+
+
+def test_service_schema_stub_rejects_undeclared_keys_by_default():
+    services_mod = _load_services_module()
+
+    try:
+        services_mod.SERVICE_DUMP_CARDS_SCHEMA({"undeclared": True})
+    except services_mod.vol.Invalid as err:
+        assert "extra keys not allowed" in str(err)
+    else:
+        raise AssertionError("service schema stub accepted an undeclared key")
+
+    allow_extra_schema = services_mod.vol.Schema(
+        {services_mod.vol.Optional("layout"): str},
+        extra=services_mod.vol.ALLOW_EXTRA,
+    )
+    assert allow_extra_schema(
+        {"layout": "v2_mobile", "undeclared": True}
+    ) == {
+        "layout": "v2_mobile",
+        "undeclared": True,
+    }
 
 
 def test_owned_ui_purge_names_are_exact_for_default_and_release_test_exports():
@@ -5946,7 +5984,7 @@ def test_create_dashboard_helper_rejects_unsafe_url_path_before_work():
                 url_path="../configuration",
             )
         )
-    except Exception as err:
+    except services_mod.HomeAssistantError as err:
         assert "Dashboard URL path" in str(err)
     else:
         raise AssertionError("unsafe dashboard path should be rejected")


### PR DESCRIPTION
## Scope

Finalize the public-safe v2.0.9 release surface before the protected `develop → main` promotion:

- cut the dated `2.0.9` changelog section and remove stale branch-local publication wording;
- make the README manifest badge resolve through `main` and remove the v2.0.9 release-note header/banner as requested;
- address the final PR #86 CodeRabbit findings by making the Voluptuous test double reject unknown keys by default and narrowing the unsafe-dashboard-path assertion to `HomeAssistantError`;
- sanitize username-bearing local-path fixtures;
- repair malformed CSS grid-area quoting in three archived gallery YAML files so every tracked YAML document parses.

## Reason

PR #86 was merged with one unresolved inline CodeRabbit thread and one final outside-diff test-harness finding. The promotion source also still described v2.0.9 through a branch-local staging state. This prerequisite keeps those corrections separate from the `develop → main` promotion and makes the final release audit reproducible.

## Files affected

- `README.md`
- `CHANGELOG.md`
- `docs/release-governance.md`
- three files under `legacy/ui-gallery/`
- `tests 2/test_doc_banners.py`
- `tests 2/test_issue_triage.py`
- `tests 2/test_runtime_card_sanity.py`

## Runtime impact

No production runtime code changes. No control lanes, priorities, service implementations, filesystem writers, or Home Assistant async paths change.

## Entity semantics

No entity names, states, attributes, availability rules, registry behavior, or service semantics change.

## UI impact

Generated dashboards and canonical V2 card output are unchanged. The v2.0.9 banner asset remains available but is no longer embedded as the README release-note header. Three archived gallery examples receive quote-only YAML syntax repairs matching their existing intended CSS grid layouts.

## Migration impact

No migration is required. No Home Assistant restart, integration reload, dashboard regeneration, cache purge, or HACS reinstall is required for this prerequisite.

## Validation performed

- `git diff --check`
- tracked Python syntax compile: 58 files
- tracked JSON parse: 7 files
- tracked YAML parse: 30/30 files
- all direct Python sanity/unit suites: passed, including 107 runtime-card checks and 30 report-export tests
- Inspector Node suite: 20/20 passed
- version governance: `branch=v2.0.9 version=2.0.9 state=stable`
- proposal links and workflow tests: passed
- HACS root layout and supported metadata-key check: passed
- Actionlint: passed
- Bandit medium-severity scan: passed
- Gitleaks full-history and tracked-content scans: passed
- high-confidence secret-pattern scan: passed
- Semgrep Python rules: three reviewed test-only advisories (trusted local sitemap parsing and two intentional `0750` directory permission assertions); no production finding
- tracked symlink/cache/temp/editor scan: passed; only the two expected repository scripts are executable
- release banner: valid 1600×900 sRGB PNG; metadata string scan found no private data

GitHub HACS, Hassfest, Validate, Gitleaks, version-governance, and CodeRabbit results remain required before merge.

## Deterministic ordering and UI truth risk

None identified. Runtime lane ordering is untouched, and no UI mapping or backend-truth contract changes.

## Rollback safety

A normal revert of this single commit restores the prior documentation, test-double, fixture, and archived YAML state. There are no persisted runtime changes or user-data migrations to undo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated release documentation to identify v2.0.9 as the stable release.
  - Clarified that GitHub Releases and HACS provide the authoritative publication and installed-version records.
  - Updated version badges and manifest links to reference the main release metadata.
  - Clarified release-readiness and version-governance guidance.
  - Marked the Unreleased section as having no pending changes.

- **Maintenance**
  - Refined dashboard configuration formatting without changing displayed humidity, temperature, or mould-related behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->