### PR TITLE
Remove the v2.0.9 README release-note header

### DIFF
--- a/README.md
+++ b/README.md
@@ -1090,8 +1090,6 @@ CO emergency pressure. Details are in
 
 ## Release Notes
 
-### v2.0.9
-
 - set integration metadata to stable `2.0.9` and aligned the release documentation;
   GitHub Releases and HACS remain the authoritative publication and installed-package
   records

--- a/tests 2/test_doc_banners.py
+++ b/tests 2/test_doc_banners.py
@@ -98,6 +98,7 @@ class DocumentationBannerTests(unittest.TestCase):
             "Humidity-Intelligence%2Fsenyo888-patch-1%2Fmanifest.json",
             readme,
         )
+        self.assertNotIn("### v2.0.9", readme)
         self.assertEqual(
             readme.count(
                 "![Humidity Intelligence v2.0.9 release banner]"

--- a/tests 2/test_runtime_card_sanity.py
+++ b/tests 2/test_runtime_card_sanity.py
@@ -3744,12 +3744,13 @@ def test_readme_uses_manifest_version_badge_not_static_ha_compatibility_badge():
     assert "Home%20Assistant-2026.4.3%2B" not in readme_source
 
 
-def test_readme_only_shows_two_latest_release_notes_before_previous_releases():
+def test_readme_shows_current_v209_notes_and_v208_before_previous_releases():
     readme_source = (ROOT / "README.md").read_text()
     release_notes = readme_source.split("## Release Notes", 1)[1]
     visible_notes, previous_releases = release_notes.split("<details>", 1)
 
-    assert "### v2.0.9" in visible_notes
+    assert "### v2.0.9" not in visible_notes
+    assert "set integration metadata to stable `2.0.9`" in visible_notes
     assert "### v2.0.8" in visible_notes
     assert "### v2.0.7" not in visible_notes
     assert "assets/release_banner/v2.0.9_release.png" not in visible_notes


### PR DESCRIPTION
## Scope

Remove the structural `### v2.0.9` header from the README release-note section, as explicitly requested by the maintainer, while retaining the v2.0.9 bullet content, the canonical `## Release Notes` section, and the separate release-banner asset.

Update the two README/documentation regression suites so neither the version header nor the release banner is reintroduced into that section.

## Reason

The first finalization pass interpreted “header” as the embedded banner image. Independent Aetherbite review correctly identified that the requested structural version header remained. This small follow-up resolves that exact blocker before the final `develop → main` promotion source is certified.

## Files affected

- `README.md`
- `tests 2/test_doc_banners.py`
- `tests 2/test_runtime_card_sanity.py`

## Runtime impact

None. No production Python, service, writer, control-engine, configuration, or entity code changes.

## Entity semantics

Unchanged.

## UI impact

No generated dashboard/card change. Only README release-note presentation changes. The v2.0.9 PNG remains available for the later GitHub Release body.

## Migration and restart impact

None for this prerequisite. No Home Assistant restart, reload, migration, export, purge, or cache action is caused by this change.

## Validation performed

- `python3 'tests 2/test_runtime_card_sanity.py'` — 107 checks passed
- `python3 'tests 2/test_doc_banners.py'` — 4 tests passed
- `git diff --check` — passed
- `VERSION_GOVERNANCE_BRANCH=v2.0.9 python3 scripts/check_version_governance.py` — stable 2.0.9 passed

Full CI, CodeRabbit, and an approving write-access review remain required before merge.

## Deterministic ordering and UI truth risk

None. The change is README/test-only.

## Rollback safety

Normal single-commit revert. No persisted data or runtime state is involved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the v2.0.9 release notes formatting for a cleaner presentation under the main Release Notes heading.

* **Tests**
  * Added and updated checks to verify the revised release-notes layout and confirm the expected v2.0.9 content remains visible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->