### PR TITLE
Gate external visual-alert and local-snapshot mutations

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -84,9 +84,10 @@ Optional frontend cards and UI dependencies must never block backend functionali
 
 External Home Assistant calls to `pause_control`, `resume_control`,
 `create_dashboard`, `purge_files`, `dump_diagnostics`, `self_check`,
-`v205_release_check`, `dump_cards`, and `view_cards` require an admin user context
-whether they target one config entry or all entries. An `entry_id` narrows the target
-only; it is not an authorization bypass.
+`v205_release_check`, `dump_cards`, `view_cards`, `flash_lights`, and
+`create_local_backup` require an admin user context whether they target one config
+entry or all entries. An `entry_id` narrows the target only; it is not an
+authorization bypass.
 
 Contextless background automation/script calls are intentionally rejected. Supported
 external use originates from an authenticated admin UI or API session; any future
@@ -101,6 +102,11 @@ cache-only and does not claim a filesystem export. Neither helper is exposed as 
 contextless service bypass. The config entry records a dashboard identifier only
 after registration succeeds. Dashboard creation authorization is separate from later
 dashboard visibility.
+
+Runtime-owned visual alerts call a separate trusted internal flashing helper after
+the deterministic engine has selected an alert lane. The public `flash_lights`
+service is admin-gated and is not the engine's control path; it cannot create,
+reorder, or override a lane decision.
 
 Generated-artifact purge must validate its full fixed target set before mutation,
 show the exact existing file and configured dashboard targets in a completed blocking

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,11 @@ No unreleased changes.
   authenticated admin UI or API session; any future automated trusted route requires
   separate design approval. First-run dashboard creation remains available through
   the trusted config-entry setup path.
+- Required authenticated admin user context for every external `flash_lights` and
+  `create_local_backup` call. Non-admin, unknown-user, and contextless callers are
+  rejected before light or snapshot mutation. Engine-owned visual alerts use a
+  separate trusted internal helper after deterministic lane selection, so alert
+  continuity, entity semantics, and lane ordering are unchanged.
 - Made `purge_files` validate its complete fixed set of direct HI-generated file and
   configured-dashboard targets before mutation, publish the exact existing target
   preview with a blocking notification, reject unsafe/non-regular filesystem

--- a/README.md
+++ b/README.md
@@ -843,6 +843,11 @@ Notes:
   context for a background automation. HI-owned setup/options and release-check
   test-card regeneration remains available through the trusted internal exporter;
   startup refresh remains cache-only.
+- Every external `flash_lights` and `create_local_backup` call requires an admin user
+  context and rejects background automations/scripts without a `user_id` before
+  light or snapshot work begins. Runtime-owned visual alerts use a separate trusted
+  internal helper after the engine selects an alert lane, so this permission boundary
+  does not change deterministic lane resolution or active-alert continuity.
 - `purge_files` validates the complete fixed HI-generated target set, posts the exact
   existing-file/dashboard preview with a blocking notification, then deletes. Any
   file or dashboard deletion failure is surfaced as an incomplete purge instead of
@@ -896,11 +901,12 @@ Common service groups:
 | `refresh_ui` | rebuild placeholder mappings and refresh cached rendered UI output |
 | `view_cards` | admin-only render/export plus an exact file-path notification |
 | `create_dashboard` | admin-only creation of a Lovelace dashboard from a rendered HI layout |
-| `flash_lights` | test configured visual alert behavior |
+| `flash_lights` | admin-only test of configured visual alert behavior; runtime alerts use the trusted engine path |
 | `pause_control` / `resume_control` | admin-only pause or resume for one supplied entry or all entries |
 | `self_check` | admin-only fixed export of mapping, generated-card entity, telemetry, drift-helper, and frontend-dependency checks |
 | `v205_release_check` | admin-only runtime-safe v2.0.5-v2.0.9 generated-card and release-validation support checks |
-| `create_local_backup` / `list_saved_versions` | manage package-local HI snapshots for advanced validation |
+| `create_local_backup` | admin-only creation of a package-local HI snapshot for advanced validation |
+| `list_saved_versions` | read-only inspection of package-local HI snapshot metadata |
 | `dump_diagnostics` | admin-only export of fuller local diagnostics for maintainer/debug workflows |
 | `purge_files` | admin-only, previewed removal of fixed generated HI artifacts with partial-failure reporting |
 
@@ -1113,6 +1119,10 @@ CO emergency pressure. Details are in
   background callers and non-admin users are rejected before work begins, while
   trusted HI setup/options/release-test generation uses the internal exporter and
   startup refresh remains cache-only
+- required an authenticated admin user context for every external `flash_lights` and
+  `create_local_backup` call; non-admin and contextless callers are rejected before
+  light or snapshot mutation, while engine-owned visual alerts use a separate
+  trusted helper after deterministic lane selection
 - extended the backward-compatible `v205_release_check` manifest contract through
   the v2.0.9 beta/rc/stable line
 - privacy-filtered local issue-triage body summaries before report escaping, removing
@@ -1130,9 +1140,10 @@ CO emergency pressure. Details are in
   root JSON/YAML remains untouched with no dual-write, copy, symlink, move, or
   automatic deletion. Verify fresh owned-directory output before switching consumers.
   Callers using another custom report filename must rename it. Contextless background
-  automations/scripts can no longer invoke the external writer services; use an
-  authenticated admin UI or API call. Any future automated trusted route requires
-  separate design approval
+  automations/scripts can no longer invoke the external writer, `flash_lights`, or
+  `create_local_backup` services; use an authenticated admin UI or API call. Runtime
+  visual-alert continuity is unchanged because the engine uses its trusted internal
+  helper. Any future automated trusted route requires separate design approval
 - runtime/UI impact: entity semantics, deterministic lane ordering, and output
   selection are unchanged. Generated-card logic and rendered backend-truth semantics
   are unchanged, while export paths and multi-entry filename qualification change.

--- a/automations/engine.py
+++ b/automations/engine.py
@@ -30,7 +30,7 @@ from ..const import (
     ZONE_OUTPUT_LEVEL_MAX,
     ZONE_OUTPUT_LEVEL_MIN,
 )
-from ..services import SERVICE_FLASH_LIGHTS
+from ..services import async_flash_lights_for_alert
 from ..helpers.parsing import hass_temperature_unit, parse_numeric, parse_temperature
 from ..helpers.seasonal import (
     condensation_risk as seasonal_condensation_risk,
@@ -863,11 +863,13 @@ class HIAutomationEngine:
                 if power_entity:
                     flash_payload["power_entity"] = power_entity
                 try:
-                    await self.hass.services.async_call(
-                        DOMAIN,
-                        SERVICE_FLASH_LIGHTS,
-                        flash_payload,
-                        blocking=False,
+                    await async_flash_lights_for_alert(
+                        self.hass,
+                        power_entity=flash_payload.get("power_entity"),
+                        lights=flash_payload["lights"],
+                        color=flash_payload["color"],
+                        duration=flash_payload["duration"],
+                        flash_count=flash_payload["flash_count"],
                     )
                 except Exception:
                     _LOGGER.exception(

--- a/docs/release-governance.md
+++ b/docs/release-governance.md
@@ -73,8 +73,9 @@ record:
 - exact diagnostics, self-check, release-check, generated-card, and registered
   dashboard paths;
 - admin rejection before work for external `dump_diagnostics`, `self_check`,
-  `v205_release_check`, `dump_cards`, and `view_cards`, continuity of trusted
-  setup/options/release-test exports, and truthful cache-only startup refresh;
+  `v205_release_check`, `dump_cards`, `view_cards`, `flash_lights`, and
+  `create_local_backup`; continuity of trusted setup/options/release-test exports
+  and engine-owned visual alerts; and truthful cache-only startup refresh;
 - single-entry and entry-qualified multi-entry filenames, exact purge preview/removal
   ownership, and retention of custom and legacy root artifacts;
 - descriptor-relative no-follow atomic writer tests, including concurrent writes,

--- a/docs/support.md
+++ b/docs/support.md
@@ -185,6 +185,11 @@ boundary. Contextless automations/scripts are rejected. HI-owned first-run, opti
 and release-check test-card regeneration continues through its trusted internal path.
 Startup refresh remains cache-only and does not claim that files were written.
 
+External `flash_lights` and `create_local_backup` calls also require authenticated
+admin user context and reject non-admin or contextless callers before light or
+snapshot work begins. Engine-owned visual alerts use a separate trusted internal
+helper after lane selection; the public service is not a parallel control path.
+
 Keep a backup of every external consumer definition before changing it. A full Home
 Assistant restart is required after installing or rolling back the package; a
 config-entry reload is suitable only for exercising already-loaded updated code.

--- a/services.py
+++ b/services.py
@@ -392,49 +392,91 @@ async def async_create_dashboard_for_entry(
     return True
 
 
+async def async_flash_lights_for_alert(
+    hass: HomeAssistant,
+    *,
+    power_entity: Optional[str] = None,
+    lights: Optional[List[str]] = None,
+    color: Optional[List[int]] = None,
+    duration: int = 10,
+    flash_count: Optional[int] = None,
+) -> None:
+    """Run one trusted HI visual-alert flash without using the public service."""
+    if power_entity:
+        try:
+            power_entity = _validate_visual_power_entity(power_entity)
+        except vol.Invalid as err:
+            raise HomeAssistantError(str(err)) from err
+
+    lights = _dedupe_lights(lights or [])
+    color_list = color or [255, 0, 0]
+    duration = max(1, int(duration))
+    rgb_color = tuple(color_list[:3]) if len(color_list) >= 3 else (255, 0, 0)
+
+    if not lights:
+        _LOGGER.debug("No lights provided for visual alert; skipping light flash.")
+        return
+
+    locks = _light_flash_locks(hass, lights)
+    acquired_locks: List[asyncio.Lock] = []
+    try:
+        for lock in locks:
+            await lock.acquire()
+            acquired_locks.append(lock)
+
+        initial_states = _capture_light_states(hass, lights)
+
+        if power_entity:
+            domain = power_entity.split(".")[0]
+            if hass.services.has_service(domain, "turn_on"):
+                try:
+                    await hass.services.async_call(
+                        domain,
+                        "turn_on",
+                        {"entity_id": power_entity},
+                        blocking=True,
+                    )
+                    await asyncio.sleep(0.5)
+                except Exception:
+                    _LOGGER.exception(
+                        "Failed to turn on alert power entity %s",
+                        power_entity,
+                    )
+
+        supports_color = {
+            light: _supports_color(hass.states.get(light))
+            for light in lights
+        }
+        await _flash_lights(
+            hass,
+            lights,
+            rgb_color,
+            duration,
+            flash_count,
+            supports_color,
+        )
+        await _restore_lights(hass, initial_states)
+    finally:
+        for lock in reversed(acquired_locks):
+            try:
+                lock.release()
+            except RuntimeError:
+                continue
+
+
 async def async_register_services(hass: HomeAssistant) -> None:
     """Register services for the integration."""
 
     async def handle_flash(call: ServiceCall) -> None:
-        power_entity = call.data.get("power_entity")
-        lights = _dedupe_lights(call.data.get("lights") or [])
-        color_list = call.data.get("color") or [255, 0, 0]
-        duration = max(1, int(call.data.get("duration", 10)))
-        flash_count = call.data.get("flash_count")
-        color = tuple(color_list[:3]) if len(color_list) >= 3 else (255, 0, 0)
-
-        if not lights:
-            _LOGGER.debug("No lights provided to flash_lights; skipping light flash.")
-            return
-
-        locks = _light_flash_locks(hass, lights)
-        acquired_locks: List[asyncio.Lock] = []
-        try:
-            for lock in locks:
-                await lock.acquire()
-                acquired_locks.append(lock)
-
-            initial_states = _capture_light_states(hass, lights)
-
-            if power_entity:
-                domain = power_entity.split(".")[0]
-                if hass.services.has_service(domain, "turn_on"):
-                    try:
-                        await hass.services.async_call(domain, "turn_on", {"entity_id": power_entity}, blocking=True)
-                        await asyncio.sleep(0.5)
-                    except Exception:
-                        _LOGGER.exception("Failed to turn on alert power entity %s", power_entity)
-
-            supports_color = {light: _supports_color(hass.states.get(light)) for light in lights}
-
-            await _flash_lights(hass, lights, color, duration, flash_count, supports_color)
-            await _restore_lights(hass, initial_states)
-        finally:
-            for lock in reversed(acquired_locks):
-                try:
-                    lock.release()
-                except RuntimeError:
-                    continue
+        await _async_require_admin_user(hass, call, SERVICE_FLASH_LIGHTS)
+        await async_flash_lights_for_alert(
+            hass,
+            power_entity=call.data.get("power_entity"),
+            lights=call.data.get("lights"),
+            color=call.data.get("color"),
+            duration=call.data.get("duration", 10),
+            flash_count=call.data.get("flash_count"),
+        )
 
     hass.services.async_register(DOMAIN, SERVICE_FLASH_LIGHTS, handle_flash, schema=SERVICE_FLASH_SCHEMA)
 
@@ -512,6 +554,7 @@ async def async_register_services(hass: HomeAssistant) -> None:
     hass.services.async_register(DOMAIN, SERVICE_DUMP_DIAGNOSTICS, handle_dump, schema=SERVICE_DUMP_SCHEMA)
 
     async def handle_create_local_backup(call: ServiceCall) -> dict:
+        await _async_require_admin_user(hass, call, SERVICE_CREATE_LOCAL_BACKUP)
         try:
             result = await async_create_local_backup(
                 hass,

--- a/services.yaml
+++ b/services.yaml
@@ -1,6 +1,6 @@
 flash_lights:
   name: Flash lights
-  description: Flash selected lights for an alert
+  description: Admin-only external action from an authenticated UI/API session; background calls without a user ID are rejected. Test selected visual-alert lights. HI runtime alerts use a separate trusted internal helper so the engine does not require or manufacture a user context.
   fields:
     power_entity:
       name: Optional power entity
@@ -108,7 +108,7 @@ v205_release_check:
           unit_of_measurement: min
 create_local_backup:
   name: Create Local HI Snapshot
-  description: Create a local HI-only snapshot of /config/custom_components/humidity_intelligence. This is not a Home Assistant backup, does not intercept HACS updates, and does not change running code until Home Assistant is restarted.
+  description: Admin-only action from an authenticated UI/API session; background calls without a user ID are rejected. Create a local HI-only snapshot of /config/custom_components/humidity_intelligence. This is not a Home Assistant backup, does not intercept HACS updates, and does not change running code until Home Assistant is restarted.
   fields:
     retain_count:
       name: Snapshots to retain

--- a/tests 2/hi_runtime_fixtures.py
+++ b/tests 2/hi_runtime_fixtures.py
@@ -222,7 +222,11 @@ def _install_package_scaffold() -> None:
         sys.modules[f"{PKG}.{sub}"] = mod
 
     services = types.ModuleType(f"{PKG}.services")
-    services.SERVICE_FLASH_LIGHTS = "flash_lights"
+
+    async def async_flash_lights_for_alert(hass, **kwargs):
+        hass.data.setdefault("_trusted_visual_alert_calls", []).append(dict(kwargs))
+
+    services.async_flash_lights_for_alert = async_flash_lights_for_alert
     sys.modules[f"{PKG}.services"] = services
 
 

--- a/tests 2/test_runtime_card_sanity.py
+++ b/tests 2/test_runtime_card_sanity.py
@@ -1826,11 +1826,12 @@ async def _run_runtime_assertions(engine_mod) -> None:
         for data in dynamic_flash_calls
     )
     assert len(engine_room_alert_dynamic._visual_alert_tasks) == 1
+    flash_call_count_before_repeat = len(dynamic_flash_calls)
     await engine_room_alert_dynamic._evaluate()
     dynamic_flash_calls_after_repeat_eval = hass_room_alert_dynamic.data[
         "_trusted_visual_alert_calls"
     ]
-    assert len(dynamic_flash_calls_after_repeat_eval) == len(dynamic_flash_calls)
+    assert len(dynamic_flash_calls_after_repeat_eval) == flash_call_count_before_repeat
     assert len(engine_room_alert_dynamic._visual_alert_tasks) == 1
     await engine_room_alert_dynamic.async_stop()
 
@@ -4410,7 +4411,7 @@ def test_external_flash_and_local_backup_require_admin_before_mutation():
                             )
                         )
                     )
-                except Exception as err:
+                except services_mod.HomeAssistantError as err:
                     assert str(err) == f"{service} requires an admin user context"
                 else:
                     raise AssertionError(

--- a/tests 2/test_runtime_card_sanity.py
+++ b/tests 2/test_runtime_card_sanity.py
@@ -357,7 +357,11 @@ def _install_package_scaffold() -> None:
         sys.modules[f"{PKG}.{sub}"] = mod
 
     services = types.ModuleType(f"{PKG}.services")
-    services.SERVICE_FLASH_LIGHTS = "flash_lights"
+
+    async def async_flash_lights_for_alert(hass, **kwargs):
+        hass.data.setdefault("_trusted_visual_alert_calls", []).append(dict(kwargs))
+
+    services.async_flash_lights_for_alert = async_flash_lights_for_alert
     sys.modules[f"{PKG}.services"] = services
 
 
@@ -584,6 +588,7 @@ class _FlashHass:
     def __init__(self, states):
         self.states = _FakeStates(states)
         self.services = _FlashServiceRegistry(self.states)
+        self.auth = _FakeAuth({"admin": SimpleNamespace(is_admin=True)})
         self.data = {}
 
 
@@ -1440,7 +1445,7 @@ async def _run_runtime_assertions(engine_mod) -> None:
     assert "_handle_aq" not in trace
 
     calls = hass.services.calls
-    assert any(domain == "humidity_intelligence" and service == "flash_lights" for domain, service, *_ in calls)
+    assert hass.data["_trusted_visual_alert_calls"]
     assert not hass.data["humidity_intelligence"][ENTRY_ID]["hi_input_booleans"]["air_downstairs_humidifier_active"].is_on
     assert any(
         domain == "fan"
@@ -1810,18 +1815,10 @@ async def _run_runtime_assertions(engine_mod) -> None:
         and data.get("percentage") == 100
         for domain, service, data, _ in hass_room_alert_dynamic.services.calls
     )
-    assert any(
-        domain == "humidity_intelligence" and service == "flash_lights"
-        for domain, service, *_ in hass_room_alert_dynamic.services.calls
-    )
-    dynamic_flash_calls = [
-        data
-        for domain, service, data, _ in hass_room_alert_dynamic.services.calls
-        if domain == "humidity_intelligence" and service == "flash_lights"
-    ]
+    dynamic_flash_calls = hass_room_alert_dynamic.data["_trusted_visual_alert_calls"]
     assert dynamic_flash_calls
     assert all(data.get("flash_count") == 10 for data in dynamic_flash_calls)
-    assert all("power_entity" not in data for data in dynamic_flash_calls)
+    assert all(data.get("power_entity") is None for data in dynamic_flash_calls)
     assert all(isinstance(data.get("color"), list) for data in dynamic_flash_calls)
     assert all(len(data.get("color")) == 3 for data in dynamic_flash_calls)
     assert all(
@@ -1830,10 +1827,8 @@ async def _run_runtime_assertions(engine_mod) -> None:
     )
     assert len(engine_room_alert_dynamic._visual_alert_tasks) == 1
     await engine_room_alert_dynamic._evaluate()
-    dynamic_flash_calls_after_repeat_eval = [
-        data
-        for domain, service, data, _ in hass_room_alert_dynamic.services.calls
-        if domain == "humidity_intelligence" and service == "flash_lights"
+    dynamic_flash_calls_after_repeat_eval = hass_room_alert_dynamic.data[
+        "_trusted_visual_alert_calls"
     ]
     assert len(dynamic_flash_calls_after_repeat_eval) == len(dynamic_flash_calls)
     assert len(engine_room_alert_dynamic._visual_alert_tasks) == 1
@@ -1876,10 +1871,7 @@ async def _run_runtime_assertions(engine_mod) -> None:
     )
     await engine_room_alert_no_lights._evaluate()
     assert hass_room_alert_no_lights.data["humidity_intelligence"][ENTRY_ID].get("runtime_mode") == "alert"
-    assert not any(
-        domain == "humidity_intelligence" and service == "flash_lights"
-        for domain, service, *_ in hass_room_alert_no_lights.services.calls
-    )
+    assert not hass_room_alert_no_lights.data.get("_trusted_visual_alert_calls")
 
     entry_room_alert_miss_data = _base_entry_data()
     entry_room_alert_miss_data["zones"]["zone1"]["enabled"] = False
@@ -3109,7 +3101,12 @@ async def _run_visual_flash_restore_assertions(services_mod) -> None:
 
         hass_on = _FlashHass({"light.alert": _FakeState("on", attrs)})
         handler_on = await _registered_flash_handler(services_mod, hass_on)
-        await handler_on(SimpleNamespace(data=payload))
+        await handler_on(
+            SimpleNamespace(
+                data=payload,
+                context=SimpleNamespace(user_id="admin"),
+            )
+        )
         on_calls = _light_service_calls(hass_on)
         assert [service for service, _data in on_calls[:20]] == ["turn_on", "turn_off"] * 10
         assert len(on_calls) == 21
@@ -3120,7 +3117,12 @@ async def _run_visual_flash_restore_assertions(services_mod) -> None:
 
         hass_off = _FlashHass({"light.alert": _FakeState("off", attrs)})
         handler_off = await _registered_flash_handler(services_mod, hass_off)
-        await handler_off(SimpleNamespace(data=payload))
+        await handler_off(
+            SimpleNamespace(
+                data=payload,
+                context=SimpleNamespace(user_id="admin"),
+            )
+        )
         off_calls = _light_service_calls(hass_off)
         assert [service for service, _data in off_calls[:20]] == ["turn_on", "turn_off"] * 10
         assert len(off_calls) == 21
@@ -3130,8 +3132,18 @@ async def _run_visual_flash_restore_assertions(services_mod) -> None:
         hass_overlap = _FlashHass({"light.alert": _FakeState("on", attrs)})
         handler_overlap = await _registered_flash_handler(services_mod, hass_overlap)
         await asyncio.gather(
-            handler_overlap(SimpleNamespace(data=payload)),
-            handler_overlap(SimpleNamespace(data=payload)),
+            handler_overlap(
+                SimpleNamespace(
+                    data=payload,
+                    context=SimpleNamespace(user_id="admin"),
+                )
+            ),
+            handler_overlap(
+                SimpleNamespace(
+                    data=payload,
+                    context=SimpleNamespace(user_id="admin"),
+                )
+            ),
         )
         overlap_services = [service for service, _data in _light_service_calls(hass_overlap)]
         one_sequence = ["turn_on", "turn_off"] * 10 + ["turn_on"]
@@ -4351,6 +4363,63 @@ def test_flash_lights_power_entity_rejects_non_switch_light_domains():
         assert "switch or light" in str(err)
     else:
         raise AssertionError("fan power_entity should be rejected")
+
+
+def test_external_flash_and_local_backup_require_admin_before_mutation():
+    services_mod = _load_services_module()
+    entry = SimpleNamespace(entry_id=ENTRY_ID, data=_base_entry_data(), options={})
+    hass = _FakeHass(entry, {"light.alert": _FakeState("off")})
+    hass.services = _FlashServiceRegistry(hass.states)
+    hass.auth = _FakeAuth(
+        {
+            "admin": SimpleNamespace(is_admin=True),
+            "viewer": SimpleNamespace(is_admin=False),
+        }
+    )
+    local_backup_calls = 0
+    original_create_local_backup = services_mod.async_create_local_backup
+
+    async def unexpected_local_backup(*_args, **_kwargs):
+        nonlocal local_backup_calls
+        local_backup_calls += 1
+        raise AssertionError("local backup work must not begin before authorization")
+
+    services_mod.async_create_local_backup = unexpected_local_backup
+    try:
+        asyncio.run(services_mod.async_register_services(hass))
+        handlers = {
+            services_mod.SERVICE_FLASH_LIGHTS: hass.services.handlers[
+                (services_mod.DOMAIN, services_mod.SERVICE_FLASH_LIGHTS)
+            ],
+            services_mod.SERVICE_CREATE_LOCAL_BACKUP: hass.services.handlers[
+                (services_mod.DOMAIN, services_mod.SERVICE_CREATE_LOCAL_BACKUP)
+            ],
+        }
+
+        for service, handler in handlers.items():
+            for user_id in ("viewer", None, "missing"):
+                calls_before = list(hass.services.calls)
+                try:
+                    asyncio.run(
+                        handler(
+                            SimpleNamespace(
+                                data={"lights": ["light.alert"]}
+                                if service == services_mod.SERVICE_FLASH_LIGHTS
+                                else {},
+                                context=SimpleNamespace(user_id=user_id),
+                            )
+                        )
+                    )
+                except Exception as err:
+                    assert str(err) == f"{service} requires an admin user context"
+                else:
+                    raise AssertionError(
+                        f"{service} should reject user context {user_id!r}"
+                    )
+                assert hass.services.calls == calls_before
+                assert local_backup_calls == 0
+    finally:
+        services_mod.async_create_local_backup = original_create_local_backup
 
 
 def test_report_service_schemas_reject_non_owned_root_filenames_before_write():


### PR DESCRIPTION
## Scope

Require authenticated admin user context for externally invoked `flash_lights` and `create_local_backup`, while keeping engine-owned visual alerts on a separate trusted internal helper.

## Reason

Both public services can mutate Home Assistant state or local snapshot storage. They must reject non-admin, unknown-user, and contextless callers before light, power-circuit, snapshot, or retention work begins. The deterministic engine still needs a trusted visual-alert path after it selects an alert lane, so runtime continuity must not depend on manufacturing a service-call user context.

## Files affected

- `services.py`
- `services.yaml`
- `automations/engine.py`
- `ARCHITECTURE.md`
- `README.md`
- `CHANGELOG.md`
- `docs/release-governance.md`
- `docs/support.md`
- `tests 2/hi_runtime_fixtures.py`
- `tests 2/test_runtime_card_sanity.py`

## Runtime impact

- External `flash_lights` and `create_local_backup` calls now require an authenticated admin user.
- Rejected calls fail before any downstream light, switch, snapshot, retention, or notification mutation begins.
- Engine-owned visual alerts call `async_flash_lights_for_alert` directly after deterministic alert-lane selection.
- Light locking, state capture/restoration, flash count, repeat suppression, exception containment, and optional power-circuit handling are preserved.

## Entity semantics

No entity IDs, state meanings, attributes, availability behavior, registry behavior, target semantics, or service names change.

## UI impact

No generated dashboard or card logic changes. Public service descriptions and support documentation now state the admin boundary. UI truth remains backend-derived.

## Migration impact

No stored-data migration. Existing background automations/scripts that invoke external `flash_lights` or `create_local_backup` without an authenticated admin user context will now be rejected and must move to an authenticated admin UI/API call. Engine-owned alerts require no user action.

A full Home Assistant restart is required after installing the package update so the updated Python service handlers load; a config-entry reload alone is insufficient.

## Validation performed

Full functional validation completed at `ab7ea4bebc803689ff03f2d7c6883439f8b18d18`. After the two CodeRabbit test-quality fixes, exact head `018a990e847a3112e235b8d37c6842aafa8a3c66` re-passed `git diff --check`, all 108 runtime/card checks, all 10 air-control simulations, and stable branch/version governance:

- `git diff --check`
- Python compile sanity
- 108 direct runtime/card checks
- 30 report-export tests
- 40 config-flow checks
- 16 diagnostics checks
- 22 Inspector Python tests and 20 Node tests
- 10 Pages tests
- 35 issue-triage tests
- 10 air-control simulations
- 13 local-version tests
- documentation-banner, setup, slope, proposal-link, version-governance, memory-auditor, and workflow tests
- tracked YAML/JSON parsing and HACS metadata/layout checks
- Actionlint
- tracked and full-history Gitleaks scans
- Bandit medium/high scan with no tracked finding
- Semgrep Python rules with only three previously reviewed test-only advisories and no production finding
- Aetherwing remediation pre-review: PASS
- CodeRabbit findings addressed: immutable repeat-call count assertion and narrowed authorization-test exception

## Deterministic lane ordering risk

None identified. The engine change replaces only the post-selection public-service handoff with the trusted internal helper. Priority order, lane eligibility, one-decision-per-cycle behavior, humidifier independence, and output selection are unchanged.

## UI truth consistency risk

None identified. Generated cards, mappings, telemetry, reason truth, and display semantics are unchanged.

## Review authority

The repository owner explicitly waived a separate third-party approval for this prerequisite on 2026-07-28. Automated CI and the substantive CodeRabbit review remain required. This waiver does not authorize merging the `develop` to `main` promotion PR, tagging, or publication.

## Rollback safety

Revert this single commit through a reviewed PR and fully restart Home Assistant. No storage migration or generated-file cleanup is required. Rollback restores the former external caller authority behavior, so the admin boundary should be retained unless a replacement trusted automation contract is explicitly designed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * External light-flashing and local-backup requests now require an authenticated administrator.
  * Unauthorized or context-free requests are rejected before any changes begin.

* **Improved Reliability**
  * Runtime visual alerts use a trusted internal flashing path, preserving alert ordering and continuity.

* **Documentation**
  * Updated service descriptions, architecture guidance, release notes, and support documentation to clarify authorization and snapshot behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


