### PR TITLE
Align v2.0.9 Wiki status with final service guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@ No unreleased changes.
   diagnostic-content egress; the only export is user-triggered copying of the
   allowlisted handoff. Native Home Assistant diagnostics remain the preferred
   support attachment and the repository/Wiki remain support truth. Wiki update
-  status: `no-op` because existing diagnostics guidance remains authoritative.
+  status: `updated`; existing diagnostics guidance remains authoritative, and the
+  Services Reference now documents the final external service permission boundaries.
   Release-documentation status: `updated` by this entry.
 - Set integration metadata to stable `2.0.9`, aligned the release documentation, and
   extended the backward-compatible `v205_release_check` manifest contract through


### PR DESCRIPTION
## Scope

Update the v2.0.9 changelog’s Wiki status from `no-op` to `updated` after publishing the final external service-permission guidance in the Wiki Services Reference.

## Reason

The later `flash_lights` and `create_local_backup` admin-gate prerequisite changed public service guidance after the earlier diagnostics-only Wiki assessment. The release record must reflect the final documentation state rather than retain the stale `no-op` label.

## Files affected

- `CHANGELOG.md`

Separate Wiki lane:

- Wiki `Services-Reference.md` at commit `88b9d2a234531181488be4001cd4c1874700abb8`

## Runtime impact

None. Documentation-only.

## Entity semantics

Unchanged.

## UI impact

No generated dashboard or card changes. The Wiki now accurately describes backend service authority and the trusted engine-owned visual-alert path.

## Migration impact

No new migration. Existing v2.0.9 guidance remains: contextless external `flash_lights` and `create_local_backup` calls are rejected, and a full Home Assistant restart is required when the package is installed.

## Validation performed

- `git diff --check`
- documentation-banner tests: 4/4 passed
- stable branch/version governance passed
- Wiki diff and public-safety scan passed
- Wiki commit pushed cleanly at `88b9d2a234531181488be4001cd4c1874700abb8`

## Deterministic lane ordering risk

None. No runtime file changes.

## UI truth consistency risk

Reduced: the Wiki now matches canonical backend authority and service behavior.

## Rollback safety

Reverting this documentation-only commit restores the prior stale label and is therefore not recommended. No restart, migration, or generated-file action is associated with this change.

## Review authority

The repository owner explicitly waived a separate third-party approval for v2.0.9 prerequisite PRs. Automated checks and documentation consistency remain required. This waiver does not authorize merging PR #88, tagging, or publication.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the 2.0.9 release documentation status to reflect finalized external service permission guidance.
  * Confirmed that the existing diagnostics guidance remains authoritative.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->