### PR TITLE
Align Pages test with final Wiki status

### DIFF
--- a/tests 2/test_pages_site.py
+++ b/tests 2/test_pages_site.py
@@ -282,7 +282,11 @@ class PagesSiteTests(unittest.TestCase):
             self.assertIn(INSPECTOR_URL, source)
             self.assertIn("native", source.lower())
             self.assertIn("preferred", source.lower())
-        self.assertIn("Wiki update status: `no-op`", normalized_changelog)
+        self.assertIn("Wiki update status: `updated`", normalized_changelog)
+        self.assertIn(
+            "Services Reference now documents the final external service permission boundaries.",
+            normalized_changelog,
+        )
         self.assertIn("Release-documentation status:", normalized_changelog)
         self.assertIn("`updated` by this entry", normalized_changelog)
 


### PR DESCRIPTION
## Scope

Align the Pages documentation contract test with the final v2.0.9 Wiki status recorded by PR #91.

## Reason

PR #91 correctly changed the changelog Wiki status from `no-op` to `updated` after the Services Reference permission guidance was published. The exact-SHA promotion gate then found that `tests 2/test_pages_site.py` still asserted the superseded status.

## Files affected

- `tests 2/test_pages_site.py`

## Runtime impact

None. This is a test-only correction. No integration runtime code, control paths, services, or generated-output writers change.

## Entity semantics

Unchanged. No entity IDs, states, attributes, availability behavior, or registry behavior change.

## UI impact

None. Generated dashboards, Lovelace output, Inspector behavior, and UI truth are unchanged.

## Migration impact

None. No migration, Home Assistant restart, reload, or dashboard refresh is required.

## Deterministic integrity

No risk to deterministic lane ordering. No lane selection or dispatch logic changes.

## UI truth consistency

No runtime/UI truth risk. The test now verifies the final public documentation statement instead of the superseded pre-update status.

## Validation performed

- `python3 'tests 2/test_pages_site.py'` — 10 passed
- `python3 'tests 2/test_doc_banners.py'` — 4 passed
- `git diff --check` — passed

## Rollback safety

Safe to revert as a single test-only commit, although reverting would restore the stale assertion and cause the final release-promotion gate to fail against the correct changelog status.