### PR TITLE
Restore the v2.0.9 README release heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -1096,6 +1096,8 @@ CO emergency pressure. Details are in
 
 ## Release Notes
 
+### v2.0.9
+
 - set integration metadata to stable `2.0.9` and aligned the release documentation;
   GitHub Releases and HACS remain the authoritative publication and installed-package
   records

--- a/tests 2/test_doc_banners.py
+++ b/tests 2/test_doc_banners.py
@@ -98,7 +98,7 @@ class DocumentationBannerTests(unittest.TestCase):
             "Humidity-Intelligence%2Fsenyo888-patch-1%2Fmanifest.json",
             readme,
         )
-        self.assertNotIn("### v2.0.9", readme)
+        self.assertIn("### v2.0.9", readme)
         self.assertEqual(
             readme.count(
                 "![Humidity Intelligence v2.0.9 release banner]"

--- a/tests 2/test_runtime_card_sanity.py
+++ b/tests 2/test_runtime_card_sanity.py
@@ -3762,7 +3762,7 @@ def test_readme_shows_current_v209_notes_and_v208_before_previous_releases():
     release_notes = readme_source.split("## Release Notes", 1)[1]
     visible_notes, previous_releases = release_notes.split("<details>", 1)
 
-    assert "### v2.0.9" not in visible_notes
+    assert "### v2.0.9" in visible_notes
     assert "set integration metadata to stable `2.0.9`" in visible_notes
     assert "### v2.0.8" in visible_notes
     assert "### v2.0.7" not in visible_notes


### PR DESCRIPTION
## Scope

Restore the `### v2.0.9` heading directly beneath the README `## Release Notes` heading and update the two documentation regressions that previously required the v2.0.9 section to remain headerless.

## Reason

The maintainer reviewed the final README approval surface and explicitly requested that the v2.0.9 title be restored. The release banner remains excluded from the README release-note section.

## Files affected

- `README.md`
- `tests 2/test_doc_banners.py`
- `tests 2/test_runtime_card_sanity.py`

## Runtime impact

None. No integration runtime code, service path, filesystem writer, control decision, or output dispatch changes.

## Entity semantics

Unchanged. No entity IDs, state meanings, attributes, availability behavior, or registry behavior change.

## Deterministic lane-order impact

None. The control engine and lane resolver are untouched.

## UI impact

No generated-dashboard or Lovelace behavior changes. This only restores a Markdown heading in the repository README. The v2.0.9 release banner remains absent from the README release-note section.

## Migration and restart impact

None. No migration, Home Assistant restart/reload, dashboard refresh, or frontend-cache action is required for this documentation-only adjustment.

## Validation performed

- `PYTHONPATH="$PWD/tests 2" python3 'tests 2/test_runtime_card_sanity.py'` — 108 checks passed
- `python3 'tests 2/test_doc_banners.py'` — 4 tests passed
- `python3 'tests 2/test_pages_site.py'` — 10 tests passed
- `git diff --check` — passed

Expected fault-injection warnings in the runtime/card suite were exercised; no test failed.

## Rollback safety

Safe to revert as one coherent documentation/test commit. Reverting would return the README to the headerless v2.0.9 release-note layout and restore the corresponding regression expectations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a dedicated `v2.0.9` heading to the README’s Release Notes section, making the release information easier to identify and navigate.

* **Tests**
  * Updated documentation checks to verify that the `v2.0.9` release heading is present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->