### PR TITLE
Address final v2.0.9 CodeRabbit findings

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -80,14 +80,15 @@ and exposed without crashing the control loop.
 
 Optional frontend cards and UI dependencies must never block backend functionality.
 
-## Mutation Service Authority
+## External Service Authority
 
 External Home Assistant calls to `pause_control`, `resume_control`,
 `create_dashboard`, `purge_files`, `dump_diagnostics`, `self_check`,
 `v205_release_check`, `dump_cards`, `view_cards`, `flash_lights`, and
 `create_local_backup` require an admin user context whether they target one config
-entry or all entries. An `entry_id` narrows the target only; it is not an
-authorization bypass.
+entry or all entries. The read-only `list_saved_versions` service is also admin-gated
+because it exposes package-local snapshot inventory through a persistent
+notification. An `entry_id` narrows a target only; it is not an authorization bypass.
 
 Contextless background automation/script calls are intentionally rejected. Supported
 external use originates from an authenticated admin UI or API session; any future

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,11 +80,13 @@ No unreleased changes.
   authenticated admin UI or API session; any future automated trusted route requires
   separate design approval. First-run dashboard creation remains available through
   the trusted config-entry setup path.
-- Required authenticated admin user context for every external `flash_lights` and
-  `create_local_backup` call. Non-admin, unknown-user, and contextless callers are
-  rejected before light or snapshot mutation. Engine-owned visual alerts use a
-  separate trusted internal helper after deterministic lane selection, so alert
-  continuity, entity semantics, and lane ordering are unchanged.
+- Required authenticated admin user context for every external `flash_lights`,
+  `create_local_backup`, and `list_saved_versions` call. Non-admin, unknown-user,
+  and contextless callers are rejected before light, snapshot, or inventory work.
+  `list_saved_versions` remains read-only but is gated because its persistent
+  notification exposes package-local snapshot metadata. Engine-owned visual alerts
+  use a separate trusted internal helper after deterministic lane selection, so
+  alert continuity, entity semantics, and lane ordering are unchanged.
 - Made `purge_files` validate its complete fixed set of direct HI-generated file and
   configured-dashboard targets before mutation, publish the exact existing target
   preview with a blocking notification, reject unsafe/non-regular filesystem

--- a/README.md
+++ b/README.md
@@ -63,11 +63,11 @@ For publication status, installed packages, and release tags, use
 [GitHub Releases](https://github.com/senyo888/Humidity-Intelligence/releases) and
 HACS as the user-facing record.
 
-v2.0.9 completes the HI-owned runtime-artifact namespace: report JSON writes
-under `<config>/humidity_intelligence/exports/`, generated card YAML writes under
-`<config>/humidity_intelligence/ui/`, and external report/card writer services
-require an authenticated admin context. GitHub Releases and HACS remain the
-authoritative publication and installed-package records.
+v2.0.9 completes the HI-owned runtime-artifact namespace: report JSON writes under
+`<config>/humidity_intelligence/exports/`, generated card YAML writes under
+`<config>/humidity_intelligence/ui/`, and protected external writer, mutation, and
+snapshot-inventory services require an authenticated admin context. GitHub Releases
+and HACS remain the authoritative publication and installed-package records.
 
 The deterministic runtime contract stays intact: one selected control lane per cycle,
 the same public entity meanings, and output writing only through the established
@@ -843,11 +843,13 @@ Notes:
   context for a background automation. HI-owned setup/options and release-check
   test-card regeneration remains available through the trusted internal exporter;
   startup refresh remains cache-only.
-- Every external `flash_lights` and `create_local_backup` call requires an admin user
-  context and rejects background automations/scripts without a `user_id` before
-  light or snapshot work begins. Runtime-owned visual alerts use a separate trusted
-  internal helper after the engine selects an alert lane, so this permission boundary
-  does not change deterministic lane resolution or active-alert continuity.
+- Every external `flash_lights`, `create_local_backup`, and `list_saved_versions`
+  call requires an admin user context and rejects background automations/scripts
+  without a `user_id` before light, snapshot, or inventory work begins.
+  `list_saved_versions` remains read-only but is gated because its notification
+  exposes package-local snapshot metadata. Runtime-owned visual alerts use a separate
+  trusted internal helper after the engine selects an alert lane, so this permission
+  boundary does not change deterministic lane resolution or active-alert continuity.
 - `purge_files` validates the complete fixed HI-generated target set, posts the exact
   existing-file/dashboard preview with a blocking notification, then deletes. Any
   file or dashboard deletion failure is surfaced as an incomplete purge instead of
@@ -906,7 +908,7 @@ Common service groups:
 | `self_check` | admin-only fixed export of mapping, generated-card entity, telemetry, drift-helper, and frontend-dependency checks |
 | `v205_release_check` | admin-only runtime-safe v2.0.5-v2.0.9 generated-card and release-validation support checks |
 | `create_local_backup` | admin-only creation of a package-local HI snapshot for advanced validation |
-| `list_saved_versions` | read-only inspection of package-local HI snapshot metadata |
+| `list_saved_versions` | admin-only, read-only inspection of package-local HI snapshot metadata |
 | `dump_diagnostics` | admin-only export of fuller local diagnostics for maintainer/debug workflows |
 | `purge_files` | admin-only, previewed removal of fixed generated HI artifacts with partial-failure reporting |
 
@@ -1121,10 +1123,11 @@ CO emergency pressure. Details are in
   background callers and non-admin users are rejected before work begins, while
   trusted HI setup/options/release-test generation uses the internal exporter and
   startup refresh remains cache-only
-- required an authenticated admin user context for every external `flash_lights` and
-  `create_local_backup` call; non-admin and contextless callers are rejected before
-  light or snapshot mutation, while engine-owned visual alerts use a separate
-  trusted helper after deterministic lane selection
+- required an authenticated admin user context for every external `flash_lights`,
+  `create_local_backup`, and `list_saved_versions` call; non-admin and contextless
+  callers are rejected before light, snapshot, or inventory work, while
+  `list_saved_versions` remains read-only and engine-owned visual alerts use a
+  separate trusted helper after deterministic lane selection
 - extended the backward-compatible `v205_release_check` manifest contract through
   the v2.0.9 beta/rc/stable line
 - privacy-filtered local issue-triage body summaries before report escaping, removing
@@ -1142,10 +1145,11 @@ CO emergency pressure. Details are in
   root JSON/YAML remains untouched with no dual-write, copy, symlink, move, or
   automatic deletion. Verify fresh owned-directory output before switching consumers.
   Callers using another custom report filename must rename it. Contextless background
-  automations/scripts can no longer invoke the external writer, `flash_lights`, or
-  `create_local_backup` services; use an authenticated admin UI or API call. Runtime
-  visual-alert continuity is unchanged because the engine uses its trusted internal
-  helper. Any future automated trusted route requires separate design approval
+  automations/scripts can no longer invoke the external writer, `flash_lights`,
+  `create_local_backup`, or `list_saved_versions` services; use an authenticated
+  admin UI or API call. Runtime visual-alert continuity is unchanged because the
+  engine uses its trusted internal helper. Any future automated trusted route
+  requires separate design approval
 - runtime/UI impact: entity semantics, deterministic lane ordering, and output
   selection are unchanged. Generated-card logic and rendered backend-truth semantics
   are unchanged, while export paths and multi-entry filename qualification change.

--- a/docs/release-governance.md
+++ b/docs/release-governance.md
@@ -67,15 +67,22 @@ review, Aetherwing runtime/release validation, AetherCore governance consistency
 review, README/release approval, and the normal release sanity checks for the exact
 branch being promoted.
 
+For v2.0.9, the promotion PR must move from draft to ready only after the local,
+house-agent, and explicit maintainer gates are complete. CodeRabbit must then finish
+an exact-head review; actionable feedback must be fixed through a prerequisite PR or
+explicitly recorded as not applicable before promotion can continue.
+
 For v2.0.9 owned-artifact namespace validation, the release packet must separately
 record:
 
 - exact diagnostics, self-check, release-check, generated-card, and registered
   dashboard paths;
 - admin rejection before work for external `dump_diagnostics`, `self_check`,
-  `v205_release_check`, `dump_cards`, `view_cards`, `flash_lights`, and
-  `create_local_backup`; continuity of trusted setup/options/release-test exports
-  and engine-owned visual alerts; and truthful cache-only startup refresh;
+  `v205_release_check`, `dump_cards`, `view_cards`, `flash_lights`,
+  `create_local_backup`, `list_saved_versions`, `pause_control`, `resume_control`,
+  `create_dashboard`, and `purge_files`; continuity of trusted
+  setup/options/release-test exports and engine-owned visual alerts; and truthful
+  cache-only startup refresh;
 - single-entry and entry-qualified multi-entry filenames, exact purge preview/removal
   ownership, and retention of custom and legacy root artifacts;
 - descriptor-relative no-follow atomic writer tests, including concurrent writes,

--- a/docs/support.md
+++ b/docs/support.md
@@ -185,10 +185,12 @@ boundary. Contextless automations/scripts are rejected. HI-owned first-run, opti
 and release-check test-card regeneration continues through its trusted internal path.
 Startup refresh remains cache-only and does not claim that files were written.
 
-External `flash_lights` and `create_local_backup` calls also require authenticated
-admin user context and reject non-admin or contextless callers before light or
-snapshot work begins. Engine-owned visual alerts use a separate trusted internal
-helper after lane selection; the public service is not a parallel control path.
+External `flash_lights`, `create_local_backup`, and `list_saved_versions` calls also
+require authenticated admin user context and reject non-admin or contextless callers
+before light, snapshot, or inventory work begins. Engine-owned visual alerts use a
+separate trusted internal helper after lane selection; the public service is not a
+parallel control path. The inventory service remains read-only but is admin-gated
+because its persistent notification exposes package-local snapshot metadata.
 
 Keep a backup of every external consumer definition before changing it. A full Home
 Assistant restart is required after installing or rolling back the package; a

--- a/helpers/report_exports.py
+++ b/helpers/report_exports.py
@@ -218,12 +218,12 @@ def _stat_regular_file(
             dir_fd=directory_fd,
             follow_symlinks=False,
         )
-    except FileNotFoundError:
+    except FileNotFoundError as err:
         if allow_absent:
             return None
         raise ReportExportError(
             f"Owned {artifact_label} changed before operation: {filename}"
-        )
+        ) from err
     except (NotImplementedError, OSError, TypeError) as err:
         raise ReportExportError(
             f"Unable to inspect owned {artifact_label} {filename!r} securely: {err}"

--- a/scripts/build_hi_inspector.py
+++ b/scripts/build_hi_inspector.py
@@ -223,7 +223,23 @@ def build(destination: pathlib.Path) -> None:
     destination.mkdir(parents=True, exist_ok=True)
     for filename in FILES:
         shutil.copyfile(SOURCE / filename, destination / filename)
-    print(f"HI Inspector static build passed: {len(FILES)} files -> {destination}")
+
+    logo_destination = (destination / OFFICIAL_LOGO_REFERENCE).resolve()
+    try:
+        logo_destination.relative_to(destination.parent)
+    except ValueError as err:
+        raise RuntimeError(
+            "Inspector logo reference must stay inside the build root"
+        ) from err
+    logo_destination.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(OFFICIAL_LOGO, logo_destination)
+    if logo_destination.read_bytes() != OFFICIAL_LOGO.read_bytes():
+        raise RuntimeError("Built Inspector logo does not match the official asset")
+
+    print(
+        "HI Inspector static build passed: "
+        f"{len(FILES)} files plus official logo -> {destination}"
+    )
 
 
 def main() -> int:

--- a/services.py
+++ b/services.py
@@ -584,6 +584,7 @@ async def async_register_services(hass: HomeAssistant) -> None:
     )
 
     async def handle_list_saved_versions(call: ServiceCall) -> dict:
+        await _async_require_admin_user(hass, call, SERVICE_LIST_SAVED_VERSIONS)
         try:
             result = await async_list_saved_versions(hass)
         except LocalVersionError as err:

--- a/services.yaml
+++ b/services.yaml
@@ -131,7 +131,7 @@ create_local_backup:
           unit_of_measurement: B
 list_saved_versions:
   name: List Local HI Snapshots
-  description: List finalized local HI-only snapshots and invalid snapshot folders. This is not a Home Assistant backup and does not change running code.
+  description: Admin-only read of finalized local HI-only snapshots and invalid snapshot folders from an authenticated UI/API session. Contextless and non-admin calls are rejected. This is not a Home Assistant backup and does not change running code.
   fields: {}
 dump_cards:
   name: Dump Cards

--- a/tests 2/test_doc_banners.py
+++ b/tests 2/test_doc_banners.py
@@ -112,6 +112,34 @@ class DocumentationBannerTests(unittest.TestCase):
             changelog.index("## 2.0.9 - 2026-07-28"),
         )
 
+    def test_v209_release_governance_requires_exact_review_and_admin_gates(self) -> None:
+        governance = (ROOT / "docs" / "release-governance.md").read_text(
+            encoding="utf-8"
+        )
+        packet = governance.split(
+            "For v2.0.9 owned-artifact namespace validation", 1
+        )[1].split("## Branch Responsibilities", 1)[0]
+
+        self.assertIn("CodeRabbit must then finish", governance)
+        self.assertIn("exact-head review", governance)
+        self.assertIn("move from draft to ready", governance)
+        for service in (
+            "dump_diagnostics",
+            "self_check",
+            "v205_release_check",
+            "dump_cards",
+            "view_cards",
+            "flash_lights",
+            "create_local_backup",
+            "list_saved_versions",
+            "pause_control",
+            "resume_control",
+            "create_dashboard",
+            "purge_files",
+        ):
+            with self.subTest(service=service):
+                self.assertIn(f"`{service}`", packet)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests 2/test_hi_inspector.py
+++ b/tests 2/test_hi_inspector.py
@@ -604,6 +604,11 @@ class HiInspectorStaticTests(unittest.TestCase):
                     (destination / filename).read_bytes(),
                     (SOURCE / filename).read_bytes(),
                 )
+            built_logo = (destination / "../assets/logo.png").resolve()
+            self.assertEqual(
+                built_logo.read_bytes(),
+                (ROOT / "assets" / "logo.png").read_bytes(),
+            )
 
     def test_static_build_refuses_source_tree_destination(self) -> None:
         completed = subprocess.run(

--- a/tests 2/test_report_exports.py
+++ b/tests 2/test_report_exports.py
@@ -57,6 +57,18 @@ class ReportExportTests(unittest.TestCase):
                 with self.assertRaises(self.exports.ReportExportError):
                     validate(candidate)
 
+    def test_required_file_disappearance_preserves_the_original_cause(self):
+        missing = FileNotFoundError("owned report disappeared")
+        with mock.patch.object(self.exports.os, "stat", side_effect=missing):
+            with self.assertRaises(self.exports.ReportExportError) as raised:
+                self.exports._stat_regular_file(
+                    1,
+                    "humidity_intelligence_race.json",
+                    allow_absent=False,
+                )
+
+        self.assertIs(raised.exception.__cause__, missing)
+
     def test_write_creates_owned_directory_and_leaves_root_report_untouched(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)

--- a/tests 2/test_runtime_card_sanity.py
+++ b/tests 2/test_runtime_card_sanity.py
@@ -4366,7 +4366,7 @@ def test_flash_lights_power_entity_rejects_non_switch_light_domains():
         raise AssertionError("fan power_entity should be rejected")
 
 
-def test_external_flash_and_local_backup_require_admin_before_mutation():
+def test_external_flash_and_local_snapshot_services_require_admin_before_work():
     services_mod = _load_services_module()
     entry = SimpleNamespace(entry_id=ENTRY_ID, data=_base_entry_data(), options={})
     hass = _FakeHass(entry, {"light.alert": _FakeState("off")})
@@ -4377,15 +4377,26 @@ def test_external_flash_and_local_backup_require_admin_before_mutation():
             "viewer": SimpleNamespace(is_admin=False),
         }
     )
-    local_backup_calls = 0
+    local_version_calls = {"create": 0, "list": 0}
     original_create_local_backup = services_mod.async_create_local_backup
+    original_list_saved_versions = services_mod.async_list_saved_versions
 
     async def unexpected_local_backup(*_args, **_kwargs):
-        nonlocal local_backup_calls
-        local_backup_calls += 1
+        local_version_calls["create"] += 1
         raise AssertionError("local backup work must not begin before authorization")
 
+    async def tracked_list_saved_versions(*_args, **_kwargs):
+        local_version_calls["list"] += 1
+        return {
+            "success": True,
+            "valid_snapshots": [],
+            "invalid_snapshots": [],
+            "latest_snapshot": None,
+            "total_size": 0,
+        }
+
     services_mod.async_create_local_backup = unexpected_local_backup
+    services_mod.async_list_saved_versions = tracked_list_saved_versions
     try:
         asyncio.run(services_mod.async_register_services(hass))
         handlers = {
@@ -4394,6 +4405,9 @@ def test_external_flash_and_local_backup_require_admin_before_mutation():
             ],
             services_mod.SERVICE_CREATE_LOCAL_BACKUP: hass.services.handlers[
                 (services_mod.DOMAIN, services_mod.SERVICE_CREATE_LOCAL_BACKUP)
+            ],
+            services_mod.SERVICE_LIST_SAVED_VERSIONS: hass.services.handlers[
+                (services_mod.DOMAIN, services_mod.SERVICE_LIST_SAVED_VERSIONS)
             ],
         }
 
@@ -4418,9 +4432,26 @@ def test_external_flash_and_local_backup_require_admin_before_mutation():
                         f"{service} should reject user context {user_id!r}"
                     )
                 assert hass.services.calls == calls_before
-                assert local_backup_calls == 0
+                assert local_version_calls == {"create": 0, "list": 0}
+
+        listed = asyncio.run(
+            handlers[services_mod.SERVICE_LIST_SAVED_VERSIONS](
+                SimpleNamespace(
+                    data={},
+                    context=SimpleNamespace(user_id="admin"),
+                )
+            )
+        )
+        assert listed["success"] is True
+        assert local_version_calls == {"create": 0, "list": 1}
+        assert any(
+            call[0:2] == ("persistent_notification", "create")
+            and call[2].get("title") == "Humidity Intelligence Local Snapshots"
+            for call in hass.services.calls
+        )
     finally:
         services_mod.async_create_local_backup = original_create_local_backup
+        services_mod.async_list_saved_versions = original_list_saved_versions
 
 
 def test_report_service_schemas_reject_non_owned_root_filenames_before_write():


### PR DESCRIPTION
## Scope

Address the final CodeRabbit findings raised on promotion PR #88 at exact head `c39cd5f`.

- make the v2.0.9 promotion checklist require the ready transition, exact-head CodeRabbit review, and every protected service rejection gate;
- preserve the original `FileNotFoundError` as the explicit cause of the owned-artifact race error;
- copy and verify the official logo at the Inspector build's referenced output-relative path;
- require authenticated-admin context for the read-only `list_saved_versions` snapshot-inventory service;
- align README, changelog, architecture, support, service metadata, and focused regression tests.

## Reason

CodeRabbit completed the promotion review with three unresolved inline findings and one outside-diff snapshot-inventory disclosure. All four were verified against current code. Official Home Assistant permission guidance requires custom integration services to enforce their own non-entity authorization, and persistent-notification retrieval is not admin-decorated, so snapshot inventory must not be exposed by an ungated service.

## Files affected

- Runtime/service boundary: `services.py`, `services.yaml`
- Owned writer error clarity: `helpers/report_exports.py`
- Inspector build: `scripts/build_hi_inspector.py`
- Public contracts: `ARCHITECTURE.md`, `README.md`, `CHANGELOG.md`, `docs/release-governance.md`, `docs/support.md`
- Regression coverage: `tests 2/test_runtime_card_sanity.py`, `tests 2/test_report_exports.py`, `tests 2/test_hi_inspector.py`, `tests 2/test_doc_banners.py`

## Runtime impact

`list_saved_versions` changes from ungated read-only access to admin-only read-only access. Non-admin, unknown-user, and contextless callers are rejected before snapshot inventory or notification work. Authenticated-admin behavior remains available and tested.

No deterministic lane ordering, target resolution, output selection, humidifier behavior, engine-owned visual-alert behavior, entity state, attribute, availability, device/entity registry, or config-flow semantics change.

The report-export change affects exception causality only; writer confinement and failure behavior are unchanged.

## UI impact

Generated dashboards and reason panels are unchanged and remain backend-truth display surfaces.

The dependency-free Inspector build now includes the official logo at the exact path referenced by its HTML, so a clean build root is complete. Inspector parsing, CSP, privacy, and network-egress behavior are unchanged.

## Migration and restart impact

No stored-data, config-entry, entity-registry, or filesystem migration is required.

Existing non-admin or background callers of `list_saved_versions` must switch to an authenticated admin UI/API session. A full Home Assistant restart remains required after installing the complete v2.0.9 package so the updated Python service handler and metadata load.

## Validation performed

- runtime/card sanity: PASS — 108 checks
- report exports: PASS — 31 tests
- Inspector Python: PASS — 22 tests
- Inspector Node: PASS — 20 tests
- documentation governance/banners: PASS — 5 tests
- Pages: PASS — 10 tests
- local versions: PASS — 13 checks
- standalone Inspector build and resolved logo: PASS
- Python in-memory compile: PASS — 58 tracked files
- JSON parse: PASS — 7 tracked files
- YAML parse: PASS — 30 tracked files
- version governance: PASS — 8 tests
- actionlint: PASS — 1.7.12
- targeted Ruff B904 and fatal-rule checks: PASS
- Bandit: PASS — no medium/high findings in changed runtime/build code
- configured secret scan: PASS
- tracked working snapshot Gitleaks: PASS
- full-history Gitleaks: PASS — 354 commits
- `git diff --check`: PASS

Expected fault-injection warnings were preserved and exercised.

## Rollback safety

This is one coherent commit and can be reverted normally. Reverting would restore the incomplete build/checklist behavior, remove explicit exception chaining, and reopen non-admin snapshot-inventory disclosure, so that privacy impact must be understood before rollback.

## Publication boundary

This prerequisite PR does not merge promotion PR #88, create a tag or GitHub Release, publish HACS, deploy or mutate Home Assistant, or authorize any of those actions. Promotion PR #88 remains draft until this prerequisite merges and all exact-head gates are repeated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Access Control**
  * Local snapshot listings now require an authenticated administrator, even though the operation is read-only.
  * Unauthorized and contextless requests are rejected before snapshot or external service work begins.

* **Documentation**
  * Updated usage guidance, release notes, architecture, support, and governance documentation to clarify administrator requirements and snapshot visibility.

* **Hi Inspector**
  * Static builds now include and validate the official Inspector logo asset.

* **Reliability**
  * File-export errors now preserve the original cause, improving diagnostics when required files are missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## GitHub review status

- Exact head: `78b23dd11bdf993cf14287d826a31a3dfeea3674`
- GitHub Validate, Gitleaks, HACS Validation, Hassfest, and version governance: PASS
- CodeRabbit: PASS — review completed with no actionable comments
- Inline review threads: none

PR #94 is ready for maintainer merge into `develop`. Promotion PR #88 remains draft and unmerged.