### PR TITLE
Harden final v2.0.9 Inspector contract tests

### DIFF
--- a/tests 2/test_hi_inspector.py
+++ b/tests 2/test_hi_inspector.py
@@ -13,6 +13,7 @@ import sys
 import tempfile
 import unittest
 from html.parser import HTMLParser
+from urllib.parse import urljoin
 
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]
@@ -190,12 +191,15 @@ class HiInspectorStaticTests(unittest.TestCase):
             parser.images,
             [("../assets/logo.png", "", "40", "40", "true")],
         )
-        self.assertIn(
-            (
-                "../",
-                "HI Support Bundle Inspector — Humidity Intelligence home",
-            ),
+        self.assertEqual(
             parser.links,
+            [
+                ("#main-content", None),
+                (
+                    "../",
+                    "HI Support Bundle Inspector — Humidity Intelligence home",
+                ),
+            ],
         )
         self.assertEqual(parser.file_inputs, 1)
         self.assertEqual(parser.file_input_tabindexes, ["-1"])
@@ -215,6 +219,8 @@ class HiInspectorStaticTests(unittest.TestCase):
         csp = parser.http_equiv["content-security-policy"]
         for directive in (
             "default-src 'none'",
+            "script-src 'self'",
+            "style-src 'self'",
             "img-src 'self'",
             "connect-src 'none'",
             "worker-src 'none'",
@@ -268,10 +274,8 @@ class HiInspectorStaticTests(unittest.TestCase):
             )
             self.assertTrue((SOURCE / reference).is_file())
         self.assertEqual(
-            base / "../assets/logo.png",
-            pathlib.PurePosixPath(
-                "/humidity-intelligence/inspector/../assets/logo.png"
-            ),
+            urljoin(f"{base}/", "../assets/logo.png"),
+            "/humidity-intelligence/assets/logo.png",
         )
         self.assertTrue((ROOT / "assets" / "logo.png").is_file())
 


### PR DESCRIPTION
## Summary

Address the three outside-diff findings from promotion PR #88's ready-state CodeRabbit review by strengthening the HI Support Bundle Inspector contract tests.

## Scope

- Require the complete expected Inspector anchor-link set so any added link fails the browser-local contract.
- Require `script-src 'self'` and `style-src 'self'` in the Inspector CSP assertions.
- Normalize the nested `../assets/logo.png` URL and assert its resolved `/humidity-intelligence/assets/logo.png` path.

## Reason

PR #88's ready-state review completed with a green status but surfaced three valid outside-diff test gaps. The production Inspector already has the correct local links, CSP, and logo reference; the regression tests were not strict enough to prove those properties against future drift.

## Files affected

- `tests 2/test_hi_inspector.py`

## Runtime impact

None. Production Python, Home Assistant services, deterministic control, output selection, and filesystem behavior are unchanged.

## Entity semantics

Unchanged. No entity ID, state, attribute, availability, registry, or config-flow behavior changes.

## Deterministic lane-order impact

None. The engine and lane resolver are untouched.

## UI and generated-dashboard impact

No rendered Inspector, Pages source, generated dashboard, card YAML, reason-panel, or UI-truth behavior changes. This PR only strengthens tests around the existing browser-local contract.

## Migration impact

None. No stored-data, file-path, dashboard, or config-entry migration is introduced.

## Restart and config-flow impact

No additional restart or config-flow impact. The existing v2.0.9 full-restart guidance remains unchanged.

## HACS and package impact

None. Metadata, package layout, HACS identity, and release wording are unchanged.

## Validation performed

- Inspector Python: 22 tests passed
- Inspector Node: 20 tests passed
- Pages: 10 tests passed
- Inspector test compile: passed
- `VERSION_GOVERNANCE_BRANCH=develop`: stable `2.0.9` passed
- configured tracked secret scan: passed
- `git diff --check`: passed

## Rollback safety

A normal one-file test-only revert restores the prior assertion coverage. Runtime behavior is unaffected either way.

## Publication boundary

This prerequisite PR targets `develop` only. It does not authorize or perform promotion PR #88's merge, branch-protection bypass, `v2.0.9` tag creation, GitHub Release or HACS publication, Pages deployment, or Home Assistant mutation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Strengthened validation of local links and security policies in the HI Inspector static bundle.
  * Added checks for explicit script and style restrictions in the Content Security Policy.
  * Improved verification that relative assets resolve correctly under nested paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## GitHub review status

- Validate, Gitleaks, HACS Validation, Hassfest, and version-governance checks passed at `5887f1908339f072ddf313a140cdf11f03faaa82`.
- CodeRabbit full review completed for the exact one-file diff with no actionable comments and zero review threads.
- PR #95 is ready for maintainer merge into `develop`.
