### PR TITLE
Address v2.0.9 promotion review findings

### DIFF
--- a/docs/release-governance.md
+++ b/docs/release-governance.md
@@ -15,7 +15,8 @@ testing and validation branches.
 The integration version in `manifest.json` is the source of truth for the installed
 Home Assistant package and integration metadata checks. When GitHub Releases are
 used, HACS derives published version state from the GitHub Release/tag; that state
-must remain aligned with the manifest.
+must remain aligned with the `manifest.json` version contained in the published
+GitHub Release/tag.
 
 The tracked source and release documentation identify stable `2.0.9`. A branch or
 merge containing stable metadata is not by itself a tag, GitHub Release, or HACS

--- a/docs/release-governance.md
+++ b/docs/release-governance.md
@@ -12,8 +12,10 @@ testing and validation branches.
   Published release status comes from release tags, GitHub release publication, and
   maintainer approval.
 
-The integration version in `manifest.json` is the release-state source of truth for
-Home Assistant and HACS metadata checks.
+The integration version in `manifest.json` is the source of truth for the installed
+Home Assistant package and integration metadata checks. When GitHub Releases are
+used, HACS derives published version state from the GitHub Release/tag; that state
+must remain aligned with the manifest.
 
 The tracked source and release documentation identify stable `2.0.9`. A branch or
 merge containing stable metadata is not by itself a tag, GitHub Release, or HACS

--- a/tests 2/test_issue_triage.py
+++ b/tests 2/test_issue_triage.py
@@ -272,7 +272,8 @@ forbidden_actions:
         self.assertIn("No GitHub issues were closed, edited, labelled, assigned, or commented on.", report)
 
     def test_malformed_or_private_maintenance_review_queue_file_becomes_warning(self) -> None:
-        action_yaml = """
+        private_path = "/" + "Users/example/private-lab"
+        action_yaml = f"""
 id: HI-MRQ-2026-002
 title: "Unsafe local action"
 owner: Unknown
@@ -282,8 +283,8 @@ priority: P1
 status: open
 source:
   type: manual
-  ref: "/Users/example/private-lab"
-instruction: "Use /Users/example/private-lab and then label the GitHub issue."
+  ref: "{private_path}"
+instruction: "Use {private_path} and then label the GitHub issue."
 completion_criteria:
   - "Unsafe instruction should not be accepted."
 allowed_actions: [report, mutate_github_issue]
@@ -333,8 +334,8 @@ forbidden_actions:
 
     def test_public_safety_rejects_cross_platform_local_paths(self) -> None:
         for local_path in (
-            "/home/example/work/private-lab",
-            r"C:\Users\Example\private-lab",
+            "/" + "home/example/work/private-lab",
+            "C:" + r"\Users\Example\private-lab",
         ):
             with self.subTest(local_path=local_path):
                 issue = self.triage._public_safety_issue({"instruction": local_path})

--- a/tests 2/test_runtime_card_sanity.py
+++ b/tests 2/test_runtime_card_sanity.py
@@ -171,9 +171,10 @@ def _install_homeassistant_stubs(*, include_unit_ratio: bool = True) -> None:
 
     ALLOW_EXTRA = object()
     PREVENT_EXTRA = object()
+    _NO_DEFAULT = object()
 
     class _SchemaKey:
-        def __init__(self, key, default=None):
+        def __init__(self, key, default=_NO_DEFAULT):
             self.key = key
             self.default = default
 
@@ -209,7 +210,7 @@ def _install_homeassistant_stubs(*, include_unit_ratio: bool = True) -> None:
                 key = key_spec.key if isinstance(key_spec, _SchemaKey) else key_spec
                 if key in value:
                     item = value[key]
-                elif isinstance(key_spec, _SchemaKey) and key_spec.default is not None:
+                elif isinstance(key_spec, _SchemaKey) and key_spec.default is not _NO_DEFAULT:
                     item = key_spec.default
                 else:
                     continue
@@ -3914,6 +3915,10 @@ def test_card_exports_are_entry_qualified_only_for_multi_entry_installations():
 
 def test_service_schema_stub_rejects_undeclared_keys_by_default():
     services_mod = _load_services_module()
+
+    release_defaults = services_mod.SERVICE_V205_RELEASE_CHECK_SCHEMA({})
+    assert release_defaults["write_test_exports"] is False
+    assert release_defaults["require_local_hi_snapshot"] is False
 
     try:
         services_mod.SERVICE_DUMP_CARDS_SCHEMA({"undeclared": True})


### PR DESCRIPTION
## Summary

Resolve the three actionable findings from the exact-head CodeRabbit full review of release promotion PR #88 (run `e68a1685-1dc1-463c-b439-ccc053f244ed`) and the one release-wording refinement found by PR #96’s own full review.

## Type

Release follow-up; documentation and test-harness correctness only.

## Scope

- distinguish installed integration metadata from GitHub Release/HACS publication authority, scoped to the manifest version contained in the published Release/tag
- construct private-looking Unix and Windows test fixture paths at runtime rather than tracking absolute local-path literals
- make the lightweight Voluptuous schema stub preserve explicit falsy defaults and assert the affected release-check defaults

## Reason

The release promotion review correctly identified ambiguous publication wording, public-safety test literals, and a test stub that did not match real Voluptuous behavior for `default=False`.

The separate outside-diff suggestion that `list_saved_versions` lacked an admin gate was verified as stale: the current handler already calls `_async_require_admin_user` before listing snapshots, and the contract is covered by tracked architecture, README, changelog, service metadata, and regression tests.

## Files affected

- `docs/release-governance.md`
- `tests 2/test_issue_triage.py`
- `tests 2/test_runtime_card_sanity.py`

## Runtime impact

None. No integration runtime code changes. Home Assistant control behavior and service behavior are unchanged.

## Entity semantics

No entity names, states, attributes, availability behavior, or registry semantics change.

## UI impact

None. Generated dashboards, cards, Inspector output, UI truth, and frontend dependency behavior are unchanged.

## UI Gallery submissions

None.

## Deterministic lane ordering

No risk. Lane selection and priority code are untouched.

## UI truth consistency

No risk. Backend telemetry and generated UI mappings are untouched.

## Migration and restart impact

No migration, reload, restart, re-export, or cache refresh is required.

## Validation performed

- `python3 'tests 2/test_runtime_card_sanity.py'` — 108 direct sanity checks passed
- `python3 'tests 2/test_issue_triage.py'` — 35 tests passed
- `python3 -m py_compile 'tests 2/test_runtime_card_sanity.py' 'tests 2/test_issue_triage.py'` — passed
- `python3 scripts/check_version_governance.py` — stable `2.0.9` accepted on governed `senyo888-patch-1`
- `git diff --check` — passed
- tracked literal scan for the three removed ambiguous/private-path patterns — no matches
- Gitleaks full-history scan — 356 commits, no leaks
- follow-up `git diff --check` and stable version governance at `e501d89` — passed

Expected fixture-error tracebacks in the runtime/card sanity script remain negative-path assertions; the suite exited successfully.

## Checks

Exact-head GitHub Validate, Gitleaks, HACS Validation, Hassfest, and version governance are green at `e501d899a5a24f47f78488aaec1e50ea703e62f6`.

CodeRabbit full review run `c0f33530-4685-4a7a-b38c-a50606498d09` found one additional wording refinement at `26fe961`. Commit `e501d89` applied the exact clarification; CodeRabbit confirmed it addressed and resolved the sole thread. The automatic broad re-review of `e501d89` was rate-limited, so it is not represented as a second full review. There are no unresolved review threads.

## Rollback safety

A single revert restores the prior documentation wording and test-harness behavior. There are no runtime artifacts, migrations, Home Assistant mutations, or generated dashboard changes to roll back.

## Release boundary

This PR is a prerequisite for PR #88 only. It does not authorize merging PR #88, creating `v2.0.9`, publishing a GitHub Release/HACS release, deploying Pages, or mutating/restarting Home Assistant.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that the integration version is determined by `manifest.json`.
  - Documented that published release metadata must remain aligned with the manifest version.

- **Tests**
  - Improved coverage for local path handling across platforms.
  - Strengthened schema validation tests, including default values and rejection of undeclared settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->