### PR TITLE
Sync main into develop before v2.0.10

### DIFF
--- a/.github/workflows/hassfest.yaml
+++ b/.github/workflows/hassfest.yaml
@@ -111,4 +111,4 @@ jobs:
           print("Staged Hassfest metadata is normalized.")
           PY
 
-      - uses: home-assistant/actions/hassfest@e3fb68ebda13d88a0d695082f471ba2c83d025fb # master
+      - uses: home-assistant/actions/hassfest@ab22029681aa532bfe7de5774a9972d67bfbd2c0 # master

--- a/.github/workflows/hassfest.yaml
+++ b/.github/workflows/hassfest.yaml
@@ -111,4 +111,4 @@ jobs:
           print("Staged Hassfest metadata is normalized.")
           PY
 
-      - uses: home-assistant/actions/hassfest@ab22029681aa532bfe7de5774a9972d67bfbd2c0 # master
+      - uses: home-assistant/actions/hassfest@a7c616ce81ccda50150bf1595786c71b1883fabb # master


### PR DESCRIPTION
## Scope

Synchronize the current `main` history back into `develop` before the v2.0.10 stable release lane proceeds.

## Reason

`main` contains two Dependabot Hassfest workflow updates that were merged after the previous branch synchronization. Restoring ancestry here keeps the required `main` to `develop` to `senyo888-patch-1` sequence explicit and reviewable.

## Files affected

- `.github/workflows/hassfest.yaml`

## Runtime impact

None. Home Assistant runtime code, deterministic lane ordering, outputs, services, entities, configuration, and diagnostics are unchanged.

## UI impact

None. Generated dashboards and UI truth are unchanged.

## Migration impact

None. No restart, reload, migration, or Stable-instance action is required.

## Validation performed

- Clean merge of `origin/main` into current `origin/develop`
- Diff limited to the Hassfest action revision
- `git diff --check`
- Confirmed `origin/main` is an ancestor of the sync head

## Rollback safety

Revert the merge commit before the release branch is synchronized if the workflow update proves unsuitable. No runtime state or user configuration is affected.

## Release-integrity notes

- Entity semantics changed: no
- Generated dashboards/UI affected: no
- Deterministic lane-ordering risk: none
- UI-truth consistency risk: none
- Hidden behavioural drift: none identified
- This PR does not promote, tag, publish, deploy, or release v2.0.10.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Home Assistant validation workflow to use a newer pinned action version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->