### PR TITLE
docs: add v2.0.10 release presentation

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -7,6 +7,7 @@ on:
       - "site/**"
       - "assets/logo.png"
       - "assets/header.png"
+      - "assets/release_banner/v2.0.10_release.png"
       - "assets/site/github-pages-hero.png"
       - "assets/ui/v2.0.10-beta.7/**"
       - "scripts/build_hi_inspector.py"
@@ -38,11 +39,12 @@ jobs:
         run: |
           set -euo pipefail
           rm -rf _site
-          mkdir -p _site/assets/site _site/assets/ui/v2.0.10-beta.7
+          mkdir -p _site/assets/release_banner _site/assets/site _site/assets/ui/v2.0.10-beta.7
           cp site/index.html site/styles.css site/robots.txt site/sitemap.xml _site/
           python3 scripts/build_hi_inspector.py _site/inspector
           cp assets/logo.png _site/assets/logo.png
           cp assets/header.png _site/assets/header.png
+          cp assets/release_banner/v2.0.10_release.png _site/assets/release_banner/v2.0.10_release.png
           cp assets/site/github-pages-hero.png _site/assets/site/github-pages-hero.png
           cp assets/ui/v2.0.10-beta.7/mobile-aq-humidifier-retrying.png _site/assets/ui/v2.0.10-beta.7/mobile-aq-humidifier-retrying.png
           cp assets/ui/v2.0.10-beta.7/tablet-zone1-cooking-output-on.jpg _site/assets/ui/v2.0.10-beta.7/tablet-zone1-cooking-output-on.jpg

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ This project follows a practical changelog format for Home Assistant and HACS us
 
 - No unreleased changes.
 
+![Humidity Intelligence v2.0.10 release banner](assets/release_banner/v2.0.10_release.png)
+
+[![Latest Release](https://img.shields.io/github/v/release/senyo888/Humidity-Intelligence?display_name=tag&sort=semver)](https://github.com/senyo888/Humidity-Intelligence/releases) [![Project Site](https://img.shields.io/badge/Project%20Site-GitHub%20Pages-5aa8d6)](https://senyo888.github.io/humidity-intelligence/) [![License](https://img.shields.io/github/license/senyo888/Humidity-Intelligence)](LICENSE) [![Sponsor](https://img.shields.io/badge/Sponsor-GitHub%20Sponsors-ea4aaa?logo=githubsponsors&logoColor=white)](https://github.com/sponsors/senyo888) [![Star Humidity Intelligence](https://img.shields.io/badge/Star%20%2F%20Support-Humidity%20Intelligence-2ea44f?logo=github&logoColor=white)](https://github.com/senyo888/humidity-intelligence)
+
 ## 2.0.10 - 2026-08-10
 
 - Fixed a diagnostics privacy gap found during Stable-instance forward validation:

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 [![Manifest Version](https://img.shields.io/badge/dynamic/json?label=Manifest%20Version&query=%24.version&url=https%3A%2F%2Fraw.githubusercontent.com%2Fsenyo888%2FHumidity-Intelligence%2Fmain%2Fcustom_components%2Fhumidity_intelligence%2Fmanifest.json&color=blue)](https://github.com/senyo888/Humidity-Intelligence/blob/main/custom_components/humidity_intelligence/manifest.json)
 [![License](https://img.shields.io/github/license/senyo888/Humidity-Intelligence)](LICENSE)
 [![Sponsor](https://img.shields.io/badge/Sponsor-GitHub%20Sponsors-ea4aaa?logo=githubsponsors&logoColor=white)](https://github.com/sponsors/senyo888)
+[![Star Humidity Intelligence](https://img.shields.io/badge/Star%20%2F%20Support-Humidity%20Intelligence-2ea44f?logo=github&logoColor=white)](https://github.com/senyo888/humidity-intelligence)
 
 ## Contents
 
@@ -1184,6 +1185,10 @@ CO emergency pressure. Details are in
 ---
 
 ## Release Notes
+
+![Humidity Intelligence v2.0.10 release banner](assets/release_banner/v2.0.10_release.png)
+
+[![Latest Release](https://img.shields.io/github/v/release/senyo888/Humidity-Intelligence?display_name=tag&sort=semver)](https://github.com/senyo888/Humidity-Intelligence/releases) [![Project Site](https://img.shields.io/badge/Project%20Site-GitHub%20Pages-5aa8d6)](https://senyo888.github.io/humidity-intelligence/) [![License](https://img.shields.io/github/license/senyo888/Humidity-Intelligence)](LICENSE) [![Sponsor](https://img.shields.io/badge/Sponsor-GitHub%20Sponsors-ea4aaa?logo=githubsponsors&logoColor=white)](https://github.com/sponsors/senyo888) [![Star Humidity Intelligence](https://img.shields.io/badge/Star%20%2F%20Support-Humidity%20Intelligence-2ea44f?logo=github&logoColor=white)](https://github.com/senyo888/humidity-intelligence)
 
 ### v2.0.10 (Stable release source; publication pending)
 

--- a/site/index.html
+++ b/site/index.html
@@ -102,6 +102,35 @@
         </div>
       </section>
 
+      <section class="release-spotlight" aria-labelledby="release-title">
+        <div class="section-inner">
+          <img
+            class="release-banner"
+            src="assets/release_banner/v2.0.10_release.png"
+            alt="Humidity Intelligence v2.0.10: The Simple Reason"
+          >
+          <div class="release-copy">
+            <p class="section-kicker">v2.0.10 release preparation</p>
+            <h2 id="release-title">The simple reason.</h2>
+            <p>
+              Humidity Intelligence remains deterministic. v2.0.10 improves how its
+              decisions, humidifier requests, observed device conditions, and degraded
+              states are explained throughout the UI. The stable source is ready; the
+              GitHub Release, tag, and HACS publication remain pending until the release
+              draft is approved and published.
+            </p>
+            <div class="release-badges" aria-label="Project and release links">
+              <a class="release-badge badge-release" href="https://github.com/senyo888/Humidity-Intelligence/releases" aria-label="Humidity Intelligence release v2.0.10"><span class="badge-key">release</span><span class="badge-value">v2.0.10</span></a>
+              <a class="release-badge badge-site" href="https://senyo888.github.io/humidity-intelligence/" aria-label="Humidity Intelligence project site on GitHub Pages"><span class="badge-key">Project Site</span><span class="badge-value">GitHub Pages</span></a>
+              <a class="release-badge badge-license" href="https://github.com/senyo888/Humidity-Intelligence/blob/main/LICENSE" aria-label="Humidity Intelligence MIT license"><span class="badge-key">license</span><span class="badge-value">MIT</span></a>
+              <a class="release-badge badge-sponsor" href="https://github.com/sponsors/senyo888" aria-label="Sponsor Humidity Intelligence through GitHub Sponsors"><span class="badge-key">♡ Sponsor</span><span class="badge-value">GitHub Sponsors</span></a>
+              <a class="release-badge badge-star" href="https://github.com/senyo888/humidity-intelligence" aria-label="Star or support Humidity Intelligence on GitHub"><span class="badge-key">★ Star / Support</span><span class="badge-value">Humidity Intelligence</span></a>
+            </div>
+            <a class="text-link" href="https://github.com/senyo888/Humidity-Intelligence#release-notes">Read the v2.0.10 release notes</a>
+          </div>
+        </div>
+      </section>
+
       <section class="intro" aria-labelledby="intro-title">
         <div class="section-inner two-column">
           <div>

--- a/site/index.html
+++ b/site/index.html
@@ -115,9 +115,10 @@
             <p>
               Humidity Intelligence remains deterministic. v2.0.10 improves how its
               decisions, humidifier requests, observed device conditions, and degraded
-              states are explained throughout the UI. The stable source is ready; the
-              GitHub Release, tag, and HACS publication remain pending until the release
-              draft is approved and published.
+              states are explained throughout the UI. Release validation, Bella and
+              AetherCore review, and maintainer README approval are complete. This remains
+              release preparation, not a published release: the GitHub Release, tag, and
+              HACS publication still require release-draft approval and explicit publication.
             </p>
             <div class="release-badges" aria-label="Project and release links">
               <a class="release-badge badge-release" href="https://github.com/senyo888/Humidity-Intelligence/releases" aria-label="Humidity Intelligence release v2.0.10"><span class="badge-key">release</span><span class="badge-value">v2.0.10</span></a>

--- a/site/styles.css
+++ b/site/styles.css
@@ -225,6 +225,85 @@ img {
   margin: 0 auto;
 }
 
+.release-spotlight {
+  padding: 64px 0;
+  background: #07111d;
+}
+
+.release-spotlight .section-inner {
+  display: grid;
+  grid-template-columns: minmax(0, 1.25fr) minmax(280px, 0.75fr);
+  gap: 36px;
+  align-items: center;
+}
+
+.release-banner {
+  display: block;
+  width: 100%;
+  border: 1px solid rgba(100, 211, 255, 0.5);
+  border-radius: 12px;
+  box-shadow: 0 18px 48px rgba(0, 0, 0, 0.34);
+}
+
+.release-copy h2,
+.release-copy p:not(.section-kicker),
+.release-copy .text-link {
+  color: #ffffff;
+}
+
+.release-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 22px 0;
+}
+
+.release-badges a,
+.release-badges img {
+  display: block;
+}
+
+.release-badge {
+  display: inline-flex !important;
+  overflow: hidden;
+  border-radius: 6px;
+  color: #ffffff;
+  font-size: 0.78rem;
+  font-weight: 800;
+  line-height: 1;
+  text-decoration: none;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.24);
+}
+
+.release-badge .badge-key,
+.release-badge .badge-value {
+  padding: 7px 9px;
+}
+
+.release-badge .badge-key {
+  background: #555b63;
+}
+
+.badge-release .badge-value {
+  background: #087fb5;
+}
+
+.badge-site .badge-value {
+  background: #4f9fc9;
+}
+
+.badge-license .badge-value {
+  background: #5da800;
+}
+
+.badge-sponsor .badge-value {
+  background: #d62d91;
+}
+
+.badge-star .badge-value {
+  background: #239447;
+}
+
 .intro,
 .feature-band,
 .gallery,
@@ -473,6 +552,7 @@ figure {
   }
 
   .two-column,
+  .release-spotlight .section-inner,
   .feature-grid,
   .screenshot-grid,
   .link-list,


### PR DESCRIPTION
## Scope

Add the v2.0.10 release header and canonical release/support badges to the README, CHANGELOG, and GitHub Pages site, and copy the committed release header into the Pages artifact.

The Wiki presentation is updated independently in the Wiki repository.

## Reason

Prepare the public release surfaces for the governed v2.0.10 draft-release review while keeping publication state explicit.

## Files affected

- `.github/workflows/pages.yml`
- `README.md`
- `CHANGELOG.md`
- `site/index.html`
- `site/styles.css`

## Runtime impact

None. No integration runtime, service implementation, configuration, storage, or output behavior changes.

## UI impact

The public documentation website gains a responsive v2.0.10 release spotlight. Generated Home Assistant dashboards and cards are unchanged.

## Entity semantics

Unchanged.

## Migration impact

None. No migration or Home Assistant restart is required for this documentation-only change.

## Deterministic integrity

- Lane ordering risk: none.
- UI truth-consistency risk: none; release publication remains described as pending.
- Hidden behavioral drift: none.

## Validation performed

- `python3 -m pytest -q "tests 2/test_pages_site.py" "tests 2/test_doc_banners.py" "tests 2/test_workflows.py" "tests 2/test_version_governance.py"` — 34 passed, 53 subtests passed
- `python3 scripts/check_version_governance.py` — PASS on `senyo888-patch-1`, version 2.0.10 stable
- `actionlint .github/workflows/pages.yml` — PASS
- `git diff --check` — PASS
- Built the exact Pages artifact locally; release header and all copied assets returned HTTP 200
- Playwright desktop 1440px and mobile 390px QA — five badges present, responsive wrapping correct, no horizontal overflow
- HI Content Harmony v1.1.5 — completed with zero blockers or unresolved wording findings; maintainer-requested README placement recorded as an accepted exception

## Rollback safety

Revert commit `0681897`. No runtime or stored-data rollback is needed.

## Maintainer’s notes

This PR is to align the final release documentation. 

This PR prepares presentation surfaces only. It does not create a tag, publish the GitHub Release, publish to HACS, or mutate Home Assistant.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a v2.0.10 release spotlight featuring release artwork, status information, project badges, and links to release notes and support resources.
  * Added a responsive dark-themed layout that adapts the spotlight for smaller screens.
* **Documentation**
  * Updated the README and changelog with the v2.0.10 release banner and project-status badges.
* **Website**
  * Published the release spotlight and banner on the project website.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->