### PR TITLE
docs: return v2.0.11 release-status correction to main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,11 @@ This project follows a practical changelog format for Home Assistant and HACS us
   post-v2.0.10
   Stability badge correction and extended the existing `v205_release_check`
   compatibility range through v2.0.11 beta/rc/stable versions. This is release
-  preparation only: v2.0.10 remains the published Stable release until the separate
-  v2.0.11 promotion, tag, GitHub Release, and HACS publication gates are completed.
+  preparation only: the v2.0.11 release source is now on `main`, while v2.0.10
+  remains the published Stable release until exact-package identity and restart
+  validation, generated release-check review, fresh Mobile and Tablet export
+  validation, required review and final maintainer approval, tagging, GitHub Release,
+  and HACS publication gates are completed.
 - Restored the established Stability preview badge treatment in generated V2 cards:
   the name's `grid-area` is now the quoted string `'n'`, preventing Home Assistant's
   YAML parser from coercing it to Boolean `false` and creating an implicit second

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@ This project follows a practical changelog format for Home Assistant and HACS us
   compatibility range through v2.0.11 beta/rc/stable versions. This is release
   preparation only: the v2.0.11 release source is now on `main`, but it must not be
   tagged or published until exact-package identity and restart validation, generated
-  release-check review, fresh Mobile and Tablet export validation, Bella verification,
+  release-check review, fresh Mobile and Tablet export validation, independent or
+  maintainer adjudication of PR `#109`'s missing approving review, Bella verification,
   AetherCore governance verification, release-sanity validation, and maintainer README
   approval are complete. v2.0.10 remains the published Stable release until the
   v2.0.11 tag, GitHub Release, and HACS publication are complete.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,12 @@ This project follows a practical changelog format for Home Assistant and HACS us
   post-v2.0.10
   Stability badge correction and extended the existing `v205_release_check`
   compatibility range through v2.0.11 beta/rc/stable versions. This is release
-  preparation only: the v2.0.11 release source is now on `main`, while v2.0.10
-  remains the published Stable release until exact-package identity and restart
-  validation, generated release-check review, fresh Mobile and Tablet export
-  validation, required review and final maintainer approval, tagging, GitHub Release,
-  and HACS publication gates are completed.
+  preparation only: the v2.0.11 release source is now on `main`, but it must not be
+  tagged or published until exact-package identity and restart validation, generated
+  release-check review, fresh Mobile and Tablet export validation, Bella verification,
+  AetherCore governance verification, release-sanity validation, and maintainer README
+  approval are complete. v2.0.10 remains the published Stable release until the
+  v2.0.11 tag, GitHub Release, and HACS publication are complete.
 - Restored the established Stability preview badge treatment in generated V2 cards:
   the name's `grid-area` is now the quoted string `'n'`, preventing Home Assistant's
   YAML parser from coercing it to Boolean `false` and creating an implicit second

--- a/README.md
+++ b/README.md
@@ -58,11 +58,12 @@ It gives you:
 - services for dashboard export, self-check, diagnostics, pause/resume, and release validation
 
 Current maintenance-candidate manifest version: **v2.0.11**. The v2.0.11 release
-source is now on `main`; the published Stable GitHub Release and tag remain
-**v2.0.10** until exact-package identity and restart validation, generated
-release-check review, fresh Mobile and Tablet export validation, required review and
-final maintainer approval, tagging, GitHub Release publication, and HACS availability
-are complete. Check HACS for installed-package availability.
+source is now on `main`, but it must not be tagged or published until exact-package
+identity and restart validation, generated release-check review, fresh Mobile and
+Tablet export validation, Bella verification, AetherCore governance verification,
+release-sanity validation, and maintainer README approval are complete. The published
+Stable GitHub Release and tag remain **v2.0.10** until the v2.0.11 tag, GitHub Release,
+and HACS availability are complete. Check HACS for installed-package availability.
 
 Optional HA Lab evidence is advisory and does not block promotion, tagging, or
 publication.
@@ -1205,10 +1206,12 @@ CO emergency pressure. Details are in
 [![Latest Release](https://img.shields.io/github/v/release/senyo888/Humidity-Intelligence?display_name=tag&sort=semver)](https://github.com/senyo888/Humidity-Intelligence/releases) [![Project Site](https://img.shields.io/badge/Project%20Site-GitHub%20Pages-5aa8d6)](https://senyo888.github.io/humidity-intelligence/) [![License](https://img.shields.io/github/license/senyo888/Humidity-Intelligence)](LICENSE) [![Sponsor](https://img.shields.io/badge/Sponsor-GitHub%20Sponsors-ea4aaa?logo=githubsponsors&logoColor=white)](https://github.com/sponsors/senyo888) [![Star Humidity Intelligence](https://img.shields.io/badge/Star%20%2F%20Support-Humidity%20Intelligence-2ea44f?logo=github&logoColor=white)](https://github.com/senyo888/humidity-intelligence)
 
 - carries stable maintenance-candidate manifest identity `2.0.11`; its release source
-  is now on `main`, while published Stable remains v2.0.10 until exact-package identity
+  is now on `main`, but it must not be tagged or published until exact-package identity
   and restart validation, generated release-check review, fresh Mobile and Tablet
-  export validation, required review and final maintainer approval, tagging, GitHub
-  Release publication, and HACS availability are complete
+  export validation, Bella verification, AetherCore governance verification,
+  release-sanity validation, and maintainer README approval are complete; published
+  Stable remains v2.0.10 until the v2.0.11 tag, GitHub Release, and HACS availability
+  are complete
 - restores the established centred Stability Score preview across generated V2
   Mobile, V2 Tablet, and both canonical gallery cards by keeping the name's
   button-card grid area as the quoted string `'n'`

--- a/README.md
+++ b/README.md
@@ -57,13 +57,17 @@ It gives you:
 - native Home Assistant diagnostics for support and triage
 - services for dashboard export, self-check, diagnostics, pause/resume, and release validation
 
-Current maintenance-candidate manifest version: **v2.0.11**. The published Stable
-GitHub Release and tag remain **v2.0.10** until the separate v2.0.11 promotion and
-publication lane is completed. Check HACS for installed-package availability.
+Current maintenance-candidate manifest version: **v2.0.11**. The v2.0.11 release
+source is now on `main`; the published Stable GitHub Release and tag remain
+**v2.0.10** until exact-package identity and restart validation, generated
+release-check review, fresh Mobile and Tablet export validation, required review and
+final maintainer approval, tagging, GitHub Release publication, and HACS availability
+are complete. Check HACS for installed-package availability.
 
-Optional HA Lab evidence is advisory and does not block promotion. Canonical tests,
-review, CI, version governance, and explicit maintainer decisions remain the release
-authority.
+Optional HA Lab evidence is advisory and does not block promotion, tagging, or
+publication.
+Canonical tests, review, CI, version governance, and explicit maintainer decisions
+remain the release authority.
 
 For publication status, installed packages, and release tags, use
 [GitHub Releases](https://github.com/senyo888/Humidity-Intelligence/releases) and
@@ -1200,9 +1204,11 @@ CO emergency pressure. Details are in
 
 [![Latest Release](https://img.shields.io/github/v/release/senyo888/Humidity-Intelligence?display_name=tag&sort=semver)](https://github.com/senyo888/Humidity-Intelligence/releases) [![Project Site](https://img.shields.io/badge/Project%20Site-GitHub%20Pages-5aa8d6)](https://senyo888.github.io/humidity-intelligence/) [![License](https://img.shields.io/github/license/senyo888/Humidity-Intelligence)](LICENSE) [![Sponsor](https://img.shields.io/badge/Sponsor-GitHub%20Sponsors-ea4aaa?logo=githubsponsors&logoColor=white)](https://github.com/sponsors/senyo888) [![Star Humidity Intelligence](https://img.shields.io/badge/Star%20%2F%20Support-Humidity%20Intelligence-2ea44f?logo=github&logoColor=white)](https://github.com/senyo888/humidity-intelligence)
 
-- carries stable maintenance-candidate manifest identity `2.0.11`; published Stable
-  remains v2.0.10 until the exact candidate completes review, promotion to `main`,
-  tagging, GitHub Release publication, and HACS availability
+- carries stable maintenance-candidate manifest identity `2.0.11`; its release source
+  is now on `main`, while published Stable remains v2.0.10 until exact-package identity
+  and restart validation, generated release-check review, fresh Mobile and Tablet
+  export validation, required review and final maintainer approval, tagging, GitHub
+  Release publication, and HACS availability are complete
 - restores the established centred Stability Score preview across generated V2
   Mobile, V2 Tablet, and both canonical gallery cards by keeping the name's
   button-card grid area as the quoted string `'n'`

--- a/docs/release-governance.md
+++ b/docs/release-governance.md
@@ -41,11 +41,16 @@ The v2.0.11 **Poetic Justice** maintenance candidate is bounded to the generated
 Stability preview correction, its fail-closed incomplete-diagnostics behavior,
 regression coverage, and the existing release-check service's version compatibility.
 It changes no lane,
-output, entity ID/state, configuration, stored data, or service name. Exact packaged
-v2.0.11 validation still requires a full Home Assistant restart after installation,
+output, entity ID/state, configuration, stored data, or service name. The release
+source is now on `main` after PR `#109`. The existing GitHub Release draft is release
+preparation only and is not publication. Before tag or publication, exact packaged
+v2.0.11 validation still requires identity confirmation and a full Home Assistant
+restart after installation, review of the generated `v205_release_check` report,
 fresh Manual-card export/replacement, and review of the rendered V2 Mobile and Tablet
-surfaces before `develop` to `main` promotion. Unsaved Manual-card playback is useful
-presentation evidence but is not exact installed-package activation evidence.
+surfaces. PR `#109` merged without a recorded approving review, so that review-gate
+exception also requires explicit independent or maintainer adjudication before
+publication. Unsaved Manual-card playback is useful presentation evidence but is not
+exact installed-package activation evidence.
 
 The former v2.0.8 candidate moved through `senyo888-patch-1`, `develop`, and `main`
 before publication. Stable metadata on a staging or review branch was not release

--- a/docs/release-governance.md
+++ b/docs/release-governance.md
@@ -49,8 +49,10 @@ restart after installation, review of the generated `v205_release_check` report,
 fresh Manual-card export/replacement, and review of the rendered V2 Mobile and Tablet
 surfaces. PR `#109` merged without a recorded approving review, so that review-gate
 exception also requires explicit independent or maintainer adjudication before
-publication. Unsaved Manual-card playback is useful presentation evidence but is not
-exact installed-package activation evidence.
+tag or publication. Bella verification, AetherCore governance verification,
+release-sanity validation, and maintainer README approval remain hard pre-tag gates.
+Unsaved Manual-card playback is useful presentation evidence but is not exact
+installed-package activation evidence.
 
 The former v2.0.8 candidate moved through `senyo888-patch-1`, `develop`, and `main`
 before publication. Stable metadata on a staging or review branch was not release

--- a/site/index.html
+++ b/site/index.html
@@ -116,9 +116,10 @@
               The v2.0.11 candidate restores the familiar centred, breathing Stability
               Score preview while keeping the card passive and Humidity Intelligence
               deterministic. The v2.0.11 release source is now on main, while Published
-              Stable remains v2.0.10. Exact-package identity and restart, release-check
-              review, fresh Mobile and Tablet validation, required review, and final
-              maintainer approval remain required before tag and publication.
+              Stable remains v2.0.10. It must not be tagged or published until
+              exact-package identity and restart, release-check review, fresh Mobile
+              and Tablet validation, required review, and final maintainer approval
+              are complete.
             </p>
             <div class="release-badges" aria-label="Project and release links">
               <a class="release-badge badge-release" href="https://github.com/senyo888/Humidity-Intelligence/releases" aria-label="Humidity Intelligence published release v2.0.10"><span class="badge-key">published release</span><span class="badge-value">v2.0.10</span></a>

--- a/site/index.html
+++ b/site/index.html
@@ -115,9 +115,10 @@
             <p>
               The v2.0.11 candidate restores the familiar centred, breathing Stability
               Score preview while keeping the card passive and Humidity Intelligence
-              deterministic. Published Stable remains v2.0.10. Exact-package restart,
-              release-check, and fresh Mobile and Tablet card validation remain required
-              before promotion.
+              deterministic. The v2.0.11 release source is now on main, while Published
+              Stable remains v2.0.10. Exact-package identity and restart, release-check
+              review, fresh Mobile and Tablet validation, required review, and final
+              maintainer approval remain required before tag and publication.
             </p>
             <div class="release-badges" aria-label="Project and release links">
               <a class="release-badge badge-release" href="https://github.com/senyo888/Humidity-Intelligence/releases" aria-label="Humidity Intelligence published release v2.0.10"><span class="badge-key">published release</span><span class="badge-value">v2.0.10</span></a>

--- a/tests 2/test_pages_site.py
+++ b/tests 2/test_pages_site.py
@@ -143,6 +143,7 @@ class PagesSiteTests(unittest.TestCase):
 
     def test_referenced_site_assets_are_public_and_copied_by_workflow(self) -> None:
         html, parser = parse_index()
+        normalized_html = " ".join(html.split())
         workflow = (ROOT / ".github/workflows/pages.yml").read_text(encoding="utf-8")
         assets = referenced_site_assets(parser)
 
@@ -151,6 +152,12 @@ class PagesSiteTests(unittest.TestCase):
         self.assertIn("assets/release_banner/v2.0.11_release.png", parser.images)
         self.assertIn("Poetic Justice.", html)
         self.assertIn("v2.0.11 maintenance candidate", html)
+        self.assertIn("v2.0.11 release source is now on main", normalized_html)
+        self.assertIn("required review", normalized_html)
+        self.assertIn("final maintainer approval", normalized_html)
+        self.assertIn("required before tag", normalized_html)
+        self.assertIn("and publication", normalized_html)
+        self.assertNotIn("before promotion.", html)
         self.assertIn("published release</span><span class=\"badge-value\">v2.0.10", html)
 
         for asset in assets:

--- a/tests 2/test_pages_site.py
+++ b/tests 2/test_pages_site.py
@@ -155,9 +155,8 @@ class PagesSiteTests(unittest.TestCase):
         self.assertIn("v2.0.11 release source is now on main", normalized_html)
         self.assertIn("required review", normalized_html)
         self.assertIn("final maintainer approval", normalized_html)
-        self.assertIn("required before tag", normalized_html)
-        self.assertIn("and publication", normalized_html)
-        self.assertNotIn("before promotion.", html)
+        self.assertIn("must not be tagged or published until", normalized_html)
+        self.assertNotIn("before promotion.", normalized_html)
         self.assertIn("published release</span><span class=\"badge-value\">v2.0.10", html)
 
         for asset in assets:

--- a/tests 2/test_runtime_card_sanity.py
+++ b/tests 2/test_runtime_card_sanity.py
@@ -4029,12 +4029,12 @@ def test_v2011_public_release_surfaces_track_post_merge_prepublication_state():
     normalized_governance = " ".join(release_governance.split())
 
     assert "v2.0.11 release source is now on `main`" in normalized_readme
-    assert (
-        "until exact-package identity and restart validation"
-        in normalized_readme
-    )
+    assert "must not be tagged or published until exact-package" in normalized_readme
     assert "generated release-check review" in normalized_readme
-    assert "required review and final maintainer approval" in normalized_readme
+    assert "Bella verification" in normalized_readme
+    assert "AetherCore governance verification" in normalized_readme
+    assert "release-sanity validation" in normalized_readme
+    assert "maintainer README approval" in normalized_readme
     assert "its release source is now on `main`" in normalized_visible_notes
     assert "promotion to `main`" not in normalized_visible_notes
     assert "v2.0.11 release source is now on `main`" in normalized_changelog
@@ -4045,7 +4045,16 @@ def test_v2011_public_release_surfaces_track_post_merge_prepublication_state():
     )
     assert "GitHub Release draft is release preparation only" in normalized_governance
     assert "merged without a recorded approving review" in normalized_governance
-    assert "Before tag or publication" in normalized_governance
+    assert (
+        "review-gate exception also requires explicit independent or maintainer "
+        "adjudication before tag or publication"
+        in normalized_governance
+    )
+    assert (
+        "Bella verification, AetherCore governance verification, release-sanity "
+        "validation, and maintainer README approval remain hard pre-tag gates"
+        in normalized_governance
+    )
     assert "until the separate v2.0.11 promotion" not in normalized_readme
     assert "v2.0.11 promotion, tag, GitHub Release" not in normalized_changelog
     assert "before `develop` to `main` promotion" not in normalized_governance

--- a/tests 2/test_runtime_card_sanity.py
+++ b/tests 2/test_runtime_card_sanity.py
@@ -4017,6 +4017,40 @@ def test_readme_keeps_candidate_and_published_stable_before_previous_releases():
     assert "<summary>Previous Releases</summary>" in previous_releases
 
 
+def test_v2011_public_release_surfaces_track_post_merge_prepublication_state():
+    readme_source = (ROOT / "README.md").read_text()
+    release_notes = readme_source.split("## Release Notes", 1)[1]
+    visible_notes = release_notes.split("<details>", 1)[0]
+    changelog_source = (ROOT / "CHANGELOG.md").read_text()
+    release_governance = (ROOT / "docs" / "release-governance.md").read_text()
+    normalized_readme = " ".join(readme_source.split())
+    normalized_visible_notes = " ".join(visible_notes.split())
+    normalized_changelog = " ".join(changelog_source.split())
+    normalized_governance = " ".join(release_governance.split())
+
+    assert "v2.0.11 release source is now on `main`" in normalized_readme
+    assert (
+        "until exact-package identity and restart validation"
+        in normalized_readme
+    )
+    assert "generated release-check review" in normalized_readme
+    assert "required review and final maintainer approval" in normalized_readme
+    assert "its release source is now on `main`" in normalized_visible_notes
+    assert "promotion to `main`" not in normalized_visible_notes
+    assert "v2.0.11 release source is now on `main`" in normalized_changelog
+    assert "exact-package identity and restart validation" in normalized_changelog
+    assert (
+        "The release source is now on `main` after PR `#109`"
+        in normalized_governance
+    )
+    assert "GitHub Release draft is release preparation only" in normalized_governance
+    assert "merged without a recorded approving review" in normalized_governance
+    assert "Before tag or publication" in normalized_governance
+    assert "until the separate v2.0.11 promotion" not in normalized_readme
+    assert "v2.0.11 promotion, tag, GitHub Release" not in normalized_changelog
+    assert "before `develop` to `main` promotion" not in normalized_governance
+
+
 def test_dump_cards_without_layout_exports_all_cached_layouts():
     services_mod = _load_services_module()
     entry = SimpleNamespace(entry_id=ENTRY_ID)

--- a/tests 2/test_runtime_card_sanity.py
+++ b/tests 2/test_runtime_card_sanity.py
@@ -4040,6 +4040,11 @@ def test_v2011_public_release_surfaces_track_post_merge_prepublication_state():
     assert "v2.0.11 release source is now on `main`" in normalized_changelog
     assert "exact-package identity and restart validation" in normalized_changelog
     assert (
+        "independent or maintainer adjudication of PR `#109`'s missing "
+        "approving review"
+        in normalized_changelog
+    )
+    assert (
         "The release source is now on `main` after PR `#109`"
         in normalized_governance
     )


### PR DESCRIPTION
## Summary

Return the reviewed v2.0.11 public release-status correction from `develop` to
`main` after PR #110 merged. This PR keeps Humidity Intelligence v2.0.11 clearly
labelled as a maintenance candidate that is not yet tagged or published; v2.0.10
remains Published Stable.

## Scope

The exact six documentation, website, and regression-test files reviewed in PR
#110. No installable integration or generated-card file changes.

## Reason

PR #109 placed the v2.0.11 release source on `main`, and PR #110 corrected the
remaining public wording that still described source promotion as pending. This PR
brings that bounded correction back to `main` before the release draft is retargeted
or any tag/publication decision is considered.

## Files affected

- `README.md`
- `CHANGELOG.md`
- `docs/release-governance.md`
- `site/index.html`
- `tests 2/test_pages_site.py`
- `tests 2/test_runtime_card_sanity.py`

## Runtime impact

None. Deterministic lane ordering, outputs, entity semantics, diagnostics, service
names and schemas, configuration, stored data, and the 52-file installable component
are unchanged.

## UI impact

The public GitHub Pages release-status wording changes intentionally. Generated
Mobile/Tablet cards, UI Gallery YAML, frontend dependencies, and backend-owned UI
truth are unchanged.

## Migration impact

None. No Home Assistant restart, config-entry migration, entity migration, dashboard
replacement, card refresh, or frontend cache action is required for this correction.

## Rollback safety

Revert this documentation/test merge if its public wording regresses. No Home
Assistant package or stored-data rollback is required.

## Validation performed

- PR #110 exact-head GitHub Actions passed before merge; its merge tree was
  byte-identical to reviewed head `dbe7485`.
- `python3 -m pytest -q "tests 2"` — 394 tests and 131 subtests passed.
- Focused Pages/runtime-card sanity run — 120 tests and 23 subtests passed.
- `VERSION_GOVERNANCE_BRANCH=senyo888-patch-1 python3 scripts/check_version_governance.py` — passed for stable v2.0.11 metadata.
- `python3 -m compileall -q custom_components/humidity_intelligence` — passed.
- `git diff --check origin/main..origin/develop` — passed.
- CodeRabbit completed its first PR #111 review and requested explicit PR #109
  approving-review adjudication in the detailed changelog plus regression coverage.
  Exact head `59d21c3` applies only that two-file correction.
- The installable component remains 52 files and is absent from this PR diff.
- HI Content Harmony 1.1.5 completed on the reviewed PR wording and changed
  changelog with zero blocking findings and no source mutation; protected
  release-authority wording was retained.
- Bella, Aetherwing, Aetherbite, and advisory AetherCore found no remaining source
  blocker on the six-file correction; Bella and Aetherbite independently passed the
  exact CodeRabbit follow-up.

## HA Lab advisory evidence

Not applicable. This is a documentation/test correction with no deployable package
or generated-card change. HA Lab remains optional and non-blocking.

## Maintainer notes

**Maintainer exception — exact head `59d21c3671db50b4a4415d0913bf3a880cb66981`**

Decision: `MAINTAINER_REVIEW_EXCEPTION_ACCEPTED_FOR_EXACT_HEAD`

I accept proceeding without a recorded approving GitHub review for PR #111 at this
exact head. This exception authorizes only my `develop` to `main` merge decision and
the corresponding ruleset bypass required for that exact merge. It does not execute
the merge.

Basis: all exact-head Actions pass; CodeRabbit's only actionable finding was fixed in
`59d21c3`, and its thread is resolved and marked addressed; the incremental rereview
was rate-limited and is not counted as a second full review; 394 tests and 131
subtests pass; Bella, Aetherwing, and Aetherbite found no remaining source blocker;
and the 52-file installable component plus runtime/generated-card bytes are unchanged.

Any new commit invalidates this exception. It does not transfer to another PR,
retroactively adjudicate PR #109's separate publication-gate exception, or authorize
a v2.0.11 tag, GitHub Release publication, HACS publication, Home Assistant mutation,
final maintainer README approval, or a Stable declaration.

## Checks

- [ ] PR targets `develop`. (Not applicable: this is the governed `develop` to `main` correction return.)
- [x] Tested in Home Assistant, or testing notes explain why not. (Not applicable: no Home Assistant bytes changed.)
- [x] Restart/config flow checked where relevant. (Not applicable.)
- [x] Ran `humidity_intelligence.refresh_ui` or refreshed dashboards where UI output changed. (Not applicable: generated UI is unchanged.)
- [x] Docs/changelog updated where needed.
- [x] Support docs, diagnostics guidance, and issue templates updated where support flow changed. (No support-flow change.)
- [x] Wiki update status recorded as `updated`, `no-op`, or `blocked` where public support/manual guidance is affected. (`no-op`.)
- [x] No private entity IDs, secrets, addresses, or personal data included.
- [x] HACS/custom integration metadata still looks correct. (Unchanged.)
- [x] Deterministic lane ordering is preserved, or the PR explicitly explains an approved semantic change.
- [x] UI truth consistency is preserved; generated UI stays anchored to backend state.
- [x] Migration impact is documented, using "none" where appropriate.
- [x] Release/readiness impact is stated, including whether Bella/Aetherwing/AetherCore review is needed.

## UI Gallery submissions

Not applicable: this PR does not add or change a UI Gallery submission.

- [ ] Uses `/ui-gallery/<card-id>/`.
- [ ] Includes `README.md`, `preview.png`, and `card.yaml` or `dashboard.yaml`.
- [ ] Top-level `ui-gallery/README.md` is updated.
- [ ] Example follows `ui-gallery/reference.txt` format.
- [ ] Required custom cards are documented.
- [ ] Preserves canonical Humidity Intelligence backend entities/helpers.
- [ ] Screenshots and YAML contain no private entity IDs, secrets, addresses, device IDs, tokens, internal URLs, or personal data.

## Maintainer summary

CodeRabbit and the independent house reviews are complete for this bounded
documentation correction. The maintainer exception above now permits my
`develop` to `main` merge decision and its needed ruleset bypass.;


